### PR TITLE
feat: Show detailed diagnostics

### DIFF
--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -39,13 +39,13 @@ export enum Request {
   lspGoto = 'lsp/goto',
   lspUses = 'lsp/uses',
 
-  pkgBenchmark = 'pkg/benchmark', // TODO
-  pkgBuild = 'pkg/build', // TODO
-  pkgBuildDoc = 'pkg/buildDoc', // TODO
-  pkgBuildJar = 'pkg/buildJar', // TODO
-  pkgBuildPkg = 'pkg/buildPkg', // TODO
-  pkgInit = 'pkg/init', // TODO
-  pkgTest = 'pkg/test', // TODO
+  pkgBenchmark = 'pkg/benchmark',
+  pkgBuild = 'pkg/build',
+  pkgBuildDoc = 'pkg/buildDoc',
+  pkgBuildJar = 'pkg/buildJar',
+  pkgBuildPkg = 'pkg/buildPkg',
+  pkgInit = 'pkg/init',
+  pkgTest = 'pkg/test',
 
   internalRestart = 'ext/restart', // Internal Extension Request
   internalDownloadLatest = 'ext/downloadLatest', // Internal Extension Request

--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -52,5 +52,6 @@ export enum Request {
   internalReady = 'ext/ready', // Internal Extension Request
   internalMessage = 'ext/message', // Internal Extension Request
   internalError = 'ext/error', // Internal Extension Request
-  internalFinishedJob = 'ext/finished' // Internal Extension Request
+  internalFinishedJob = 'ext/finished', // Internal Extension Request
+  internalDiagnostics = 'ext/diagnostics' // Internal Extension Request
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -29,6 +29,8 @@ const readyEventEmitter = new EventEmitter()
 
 let outputChannel: vscode.OutputChannel
 
+let diagnosticsOutputChannel: vscode.OutputChannel
+
 function showStartupProgress () {
   vscode.window.withProgress({
     location: vscode.ProgressLocation.Notification,
@@ -98,6 +100,7 @@ function makeHandleRunCommand (request: jobs.Request, title: string, timeout: nu
 
 export async function activate (context: vscode.ExtensionContext, launchOptions: LaunchOptions = defaultLaunchOptions) {
   outputChannel = vscode.window.createOutputChannel('Flix Extension')
+  diagnosticsOutputChannel = vscode.window.createOutputChannel('Flix Errors')
   
   client = createLanguageClient({ context, outputChannel })
 
@@ -202,5 +205,6 @@ export function deactivate (): Thenable<void> | undefined {
   }
   flixWatcher.dispose()
   outputChannel.dispose()
+  diagnosticsOutputChannel.dispose()
   return client.stop()
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -118,7 +118,7 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   
   client = createLanguageClient({ context, outputChannel })
 
-  outputChannel.show()
+  outputChannel.show(true)
 
   // Start the client. This will also launch the server
   client.start()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -98,6 +98,20 @@ function makeHandleRunCommand (request: jobs.Request, title: string, timeout: nu
   }
 }
 
+function handlePrintDiagnostics ({ status, result }) {
+  diagnosticsOutputChannel.clear()
+  if (status === 'success') {
+    diagnosticsOutputChannel.appendLine(`${String.fromCodePoint(0x2705)} No errors ${String.fromCodePoint(0x2705)}`)
+  } else {
+    for (const res of result) {
+      for (const diag of res.diagnostics) {
+        diagnosticsOutputChannel.appendLine(`${String.fromCodePoint(0x274C)} ${diag.fullMessage}`)
+      }
+    }
+  }
+  diagnosticsOutputChannel.show(true)
+}
+
 export async function activate (context: vscode.ExtensionContext, launchOptions: LaunchOptions = defaultLaunchOptions) {
   outputChannel = vscode.window.createOutputChannel('Flix Extension')
   diagnosticsOutputChannel = vscode.window.createOutputChannel('Flix Errors')
@@ -191,6 +205,8 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
     // only one job runs at once, so currently not trying to distinguish
     readyEventEmitter.emit(jobs.Request.internalFinishedJob)
   })
+
+  client.onNotification(jobs.Request.internalDiagnostics, handlePrintDiagnostics)
 
   client.onNotification(jobs.Request.internalRestart, restartClient(context))
 

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -39,13 +39,13 @@ export enum Request {
   lspGoto = 'lsp/goto',
   lspUses = 'lsp/uses',
 
-  pkgBenchmark = 'pkg/benchmark', // TODO
-  pkgBuild = 'pkg/build', // TODO
-  pkgBuildDoc = 'pkg/buildDoc', // TODO
-  pkgBuildJar = 'pkg/buildJar', // TODO
-  pkgBuildPkg = 'pkg/buildPkg', // TODO
-  pkgInit = 'pkg/init', // TODO
-  pkgTest = 'pkg/test', // TODO
+  pkgBenchmark = 'pkg/benchmark',
+  pkgBuild = 'pkg/build',
+  pkgBuildDoc = 'pkg/buildDoc',
+  pkgBuildJar = 'pkg/buildJar',
+  pkgBuildPkg = 'pkg/buildPkg',
+  pkgInit = 'pkg/init',
+  pkgTest = 'pkg/test',
 
   internalRestart = 'ext/restart', // Internal Extension Request
   internalDownloadLatest = 'ext/downloadLatest', // Internal Extension Request

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -52,7 +52,8 @@ export enum Request {
   internalReady = 'ext/ready', // Internal Extension Request
   internalMessage = 'ext/message', // Internal Extension Request
   internalError = 'ext/error', // Internal Extension Request
-  internalFinishedJob = 'ext/finished' // Internal Extension Request
+  internalFinishedJob = 'ext/finished', // Internal Extension Request
+  internalDiagnostics = 'ext/diagnostics' // Internal Extension Request
 }
 
 export interface Position {

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -242,6 +242,7 @@ function makeVersionResponseHandler (promiseResolver: Function) {
  */
 export function lspCheckResponseHandler ({ status, result }: socket.FlixResponse) {
   clearDiagnostics()
+  sendNotification(jobs.Request.internalDiagnostics, { status, result })
   if (status !== 'success') {
     _.each(sendDiagnostics, result)
   }


### PR DESCRIPTION
- Add additional output window called "Flix Errors" (the other one is called "Flix Extension")
- When check runs successfully, show "Flix Errors" with "No errors"
- When check runs with errors, show "Flix Errors" with all `fullMessage` of the errors

Fixes #27 
Fixes #35