### PR TITLE
feat: Installation and Upgrades

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -6,6 +6,7 @@ import * as jobs from './engine/jobs'
 
 import ensureFlixExists from './util/ensureFlixExists'
 import createLanguageClient from './util/createLanguageClient'
+import initialiseState from './services/state'
 
 const _ = require('lodash/fp')
 
@@ -120,6 +121,9 @@ function handlePrintDiagnostics ({ status, result }) {
 }
 
 export async function activate (context: vscode.ExtensionContext, launchOptions: LaunchOptions = defaultLaunchOptions) {
+  // activate state
+  initialiseState(context)
+
   outputChannel = vscode.window.createOutputChannel('Flix Extension')
   diagnosticsOutputChannel = vscode.window.createOutputChannel('Flix Errors')
   

--- a/client/src/services/releases.ts
+++ b/client/src/services/releases.ts
@@ -32,38 +32,8 @@ export function assert (condition: boolean, explanation: string): asserts condit
   }
 }
 
-export async function getDownloadUrl () {
-  const dummyRelease = {
-    assets: [{ browser_download_url: 'https://github.com/flix/flix/releases/download/v0.14.0/flix.jar' }]
-  }
-  const release = dummyRelease || (await fetchRelease('latest'))
-  return _.get('assets.0.browser_download_url', release)
-}
-
-export async function fetchReleaseWithFallback (
+export async function fetchRelease (
   releaseTag: string = 'latest',
-  githubToken?: string | null | undefined
-): Promise<FlixRelease> {
-  try {
-    return fetchRelease(releaseTag, githubToken)
-  } catch (_err) {
-    // failed fetching release for some reason, so return our fallback
-    return {
-      url: 'https://api.github.com/repos/flix/flix/releases/32408169',
-      id: 32408169,
-      name: 'Version 0.14.0',
-      version:  {
-        major: 0,
-        minor: 14,
-        patch: 0
-      },
-      downloadUrl: 'https://github.com/flix/flix/releases/download/v0.14.0/flix.jar'
-    }
-  }
-}
-
-async function fetchRelease (
-  releaseTag: string,
   githubToken?: string | null | undefined
 ): Promise<FlixRelease> {
   const apiEndpointPath = `/repos/${OWNER}/${REPO}/releases/${releaseTag}`

--- a/client/src/services/releases.ts
+++ b/client/src/services/releases.ts
@@ -40,10 +40,32 @@ export async function getDownloadUrl () {
   return _.get('assets.0.browser_download_url', release)
 }
 
-export async function fetchRelease (
+export async function fetchReleaseWithFallback (
+  releaseTag: string = 'latest',
+  githubToken?: string | null | undefined
+): Promise<FlixRelease> {
+  try {
+    return fetchRelease(releaseTag, githubToken)
+  } catch (_err) {
+    // failed fetching release for some reason, so return our fallback
+    return {
+      url: 'https://api.github.com/repos/flix/flix/releases/32408169',
+      id: 32408169,
+      name: 'Version 0.14.0',
+      version:  {
+        major: 0,
+        minor: 14,
+        patch: 0
+      },
+      downloadUrl: 'https://github.com/flix/flix/releases/download/v0.14.0/flix.jar'
+    }
+  }
+}
+
+async function fetchRelease (
   releaseTag: string,
   githubToken?: string | null | undefined
-): Promise<GithubRelease> {
+): Promise<FlixRelease> {
   const apiEndpointPath = `/repos/${OWNER}/${REPO}/releases/${releaseTag}`
 
   const requestUrl = GITHUB_API_ENDPOINT_URL + apiEndpointPath
@@ -76,11 +98,49 @@ export async function fetchRelease (
 
   // We skip runtime type checks for simplicity (here we cast from `any` to `GithubRelease`)
   const release: GithubRelease = await response.json()
-  return release
+  const flixRelease: FlixRelease = {
+    url: _.get('url', release),
+    id: _.get('id', release),
+    name: _.get('name', release),
+    version: tagToVersion(_.get('tag_name', release)),
+    downloadUrl: _.get('assets.0.browser_download_url', release)
+  }
+  return flixRelease
+}
+
+function tagToVersion (tagName: string = ''): FlixVersion {
+  const versionString = tagName[0] === 'v' ? tagName.substr(1) : tagName
+  const [major, minor, patch] = _.map(_.parseInt(10), _.split('.', versionString))
+  return {
+    major,
+    minor,
+    patch
+  }
+}
+
+export function firstNewerThanSecond (first: FlixRelease, second: FlixRelease): boolean {
+  if (!second || !second.version || second.version.major === undefined || second.version.minor === undefined || second.version.patch === undefined) {
+    return true
+  }
+  return (first.version.major > second.version.major) || (first.version.minor > second.version.minor) || (first.version.patch > second.version.patch)
+}
+
+export interface FlixVersion {
+  major: number
+  minor: number
+  patch: number
+}
+
+export interface FlixRelease {
+  url: string
+  id: number
+  name: string
+  version: FlixVersion
+  downloadUrl: string
 }
 
 // We omit declaration of tremendous amount of fields that we are not using here
-export interface GithubRelease {
+interface GithubRelease {
     name: string
     id: number
     // eslint-disable-next-line camelcase

--- a/client/src/services/state.ts
+++ b/client/src/services/state.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Thomas Plougsgaard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as vscode from 'vscode'
+import { FlixRelease } from './releases'
+
+let globalState: vscode.Memento
+
+export default function initialise (context: vscode.ExtensionContext) {
+  globalState = context.globalState
+}
+
+enum StateKeys {
+  installedFlixVersion = 'installedFlixVersion' 
+}
+
+export function getInstalledFlixVersion (): FlixRelease {
+  return globalState?.get(StateKeys.installedFlixVersion)
+}
+
+export async function setInstalledFlixVersion (value) {
+  return globalState?.update(StateKeys.installedFlixVersion, value)
+}

--- a/client/src/util/ensureFlixExists.ts
+++ b/client/src/util/ensureFlixExists.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as vscode from 'vscode'
 
-import { download, fetchReleaseWithFallback, firstNewerThanSecond, FlixRelease } from '../services/releases'
+import { download, fetchRelease, firstNewerThanSecond, FlixRelease } from '../services/releases'
 import { getInstalledFlixVersion, setInstalledFlixVersion } from '../services/state'
 
 const FLIX_JAR = 'flix.jar'
@@ -40,7 +40,7 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
     const filename = path.join(globalStoragePath, FLIX_JAR)
     if (fs.existsSync(filename)) {
       // Check if a newer version is available
-      const flixRelease = await fetchReleaseWithFallback()
+      const flixRelease = await fetchRelease()
       const installedFlixRelease: FlixRelease = getInstalledFlixVersion()
       // Give the user the option to update if there's a newer version available
       if (firstNewerThanSecond(flixRelease, installedFlixRelease)) {
@@ -82,7 +82,7 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
   }
 
   await downloadWithRetryDialog(async () => {
-    const flixRelease = await fetchReleaseWithFallback()
+    const flixRelease = await fetchRelease()
     await download({
       url: flixRelease.downloadUrl,
       dest: filename,

--- a/client/src/util/ensureFlixExists.ts
+++ b/client/src/util/ensureFlixExists.ts
@@ -2,7 +2,8 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as vscode from 'vscode'
 
-import { download, getDownloadUrl } from '../services/releases'
+import { download, fetchReleaseWithFallback, firstNewerThanSecond, FlixRelease } from '../services/releases'
+import { getInstalledFlixVersion, setInstalledFlixVersion } from '../services/state'
 
 const FLIX_JAR = 'flix.jar'
 
@@ -38,19 +39,42 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
     // 2. If `flix.jar` exists in `globalStoragePath`, use that
     const filename = path.join(globalStoragePath, FLIX_JAR)
     if (fs.existsSync(filename)) {
+      // Check if a newer version is available
+      const flixRelease = await fetchReleaseWithFallback()
+      const installedFlixRelease: FlixRelease = getInstalledFlixVersion()
+      // Give the user the option to update if there's a newer version available
+      console.log({flixRelease, installedFlixRelease})
+      if (firstNewerThanSecond(flixRelease, installedFlixRelease)) {
+        const updateResponse = await vscode.window.showInformationMessage(
+          `A new version of the Flix compiler (${flixRelease.name}) is available. Download?`,
+          'Download',
+          'Skip'
+        )
+        if (updateResponse === 'Download') {
+          await downloadWithRetryDialog(async () => {
+            await download({
+              url: flixRelease.downloadUrl,
+              dest: filename,
+              progressTitle: 'Downloading Flix Compiler',
+              overwrite: true
+            })
+            await setInstalledFlixVersion(flixRelease)
+          })
+        }
+      }
+      
       return filename
     }
   }
   // 3. Otherwise download `FLIX_URL` into `globalStoragePath` (create folder if necessary)
   const filename = path.join(globalStoragePath, FLIX_JAR)
-  const downloadUrl = await getDownloadUrl()
-  
+    
   if (!fs.existsSync(globalStoragePath)) {
     fs.mkdirSync(globalStoragePath)
   }
 
   const userResponse = await vscode.window.showInformationMessage(
-    'Flix needs to be downloaded. Proceed?',
+    'This plugin requires the Flix compiler. Do you want to download it now?',
     'Download'
   )
 
@@ -59,12 +83,14 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
   }
 
   await downloadWithRetryDialog(async () => {
+    const flixRelease = await fetchReleaseWithFallback()
     await download({
-      url: downloadUrl,
+      url: flixRelease.downloadUrl,
       dest: filename,
-      progressTitle: "Downloading Flix Compiler",
-      overwrite: true,
+      progressTitle: 'Downloading Flix Compiler',
+      overwrite: true
     })
+    await setInstalledFlixVersion(flixRelease)
   })
 
   return filename

--- a/client/src/util/ensureFlixExists.ts
+++ b/client/src/util/ensureFlixExists.ts
@@ -43,7 +43,6 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
       const flixRelease = await fetchReleaseWithFallback()
       const installedFlixRelease: FlixRelease = getInstalledFlixVersion()
       // Give the user the option to update if there's a newer version available
-      console.log({flixRelease, installedFlixRelease})
       if (firstNewerThanSecond(flixRelease, installedFlixRelease)) {
         const updateResponse = await vscode.window.showInformationMessage(
           `A new version of the Flix compiler (${flixRelease.name}) is available. Download?`,


### PR DESCRIPTION
- Store currently installed version in global state
- When using workspace jar, do nothing
- When using global jar, check upon startup if a newer version is available
- Prompt user to download or skip

Fixes #49 