### PR TITLE
feat: Skip fetch release if done recently

### DIFF
--- a/client/src/services/releases.ts
+++ b/client/src/services/releases.ts
@@ -73,7 +73,8 @@ export async function fetchRelease (
     id: _.get('id', release),
     name: _.get('name', release),
     version: tagToVersion(_.get('tag_name', release)),
-    downloadUrl: _.get('assets.0.browser_download_url', release)
+    downloadUrl: _.get('assets.0.browser_download_url', release),
+    downloadedAt: Date.now()
   }
   return flixRelease
 }
@@ -107,6 +108,7 @@ export interface FlixRelease {
   name: string
   version: FlixVersion
   downloadUrl: string
+  downloadedAt: number
 }
 
 // We omit declaration of tremendous amount of fields that we are not using here

--- a/client/src/util/ensureFlixExists.ts
+++ b/client/src/util/ensureFlixExists.ts
@@ -39,9 +39,16 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
     // 2. If `flix.jar` exists in `globalStoragePath`, use that
     const filename = path.join(globalStoragePath, FLIX_JAR)
     if (fs.existsSync(filename)) {
+      const installedFlixRelease: FlixRelease = getInstalledFlixVersion()
+      const thirtyMinutesInMilliseconds = 1000 * 60 * 30
+
+      // skip if we checked under 30 minutes ago
+      if (Date.now() < ((installedFlixRelease.downloadedAt || 0) + thirtyMinutesInMilliseconds)) {
+        return filename
+      }
+
       // Check if a newer version is available
       const flixRelease = await fetchRelease()
-      const installedFlixRelease: FlixRelease = getInstalledFlixVersion()
       // Give the user the option to update if there's a newer version available
       if (firstNewerThanSecond(flixRelease, installedFlixRelease)) {
         const updateResponse = await vscode.window.showInformationMessage(


### PR DESCRIPTION
- Save timestamp when fetching release
- If release was fetched under 30 minutes ago, don't fetch another one

Fixes #58 