### PR TITLE
Use $JAVA_HOME to find Java binary

### DIFF
--- a/server/src/util/javaVersion.ts
+++ b/server/src/util/javaVersion.ts
@@ -34,12 +34,10 @@ const getMajorVersion = _.flow(
   _.parseInt(10)
 )
 
-export default async function javaMajorVersion (rootPath: string): Promise<JavaVersion> {
+export default async function javaMajorVersion (rootPath: string, javaPath: string): Promise<JavaVersion> {
   return new Promise((resolve) => {
-    ChildProcess.exec('java CheckJavaVersion', { cwd: path.join(rootPath, 'java') }, (error: any, stdout: any, stderror: any) => {
-      if (error) {
-        return resolve(unknownJavaVersion)
-      }
+    ChildProcess.exec(`${javaPath} CheckJavaVersion`, { cwd: path.join(rootPath, 'java') }, (error: any, stdout: any, stderror: any) => {
+      if (error) throw error
       if (typeof stdout !== 'string') {
         return resolve(unknownJavaVersion)
       }


### PR DESCRIPTION
I'm using [asdf](https://asdf-vm.com) with https://github.com/halcyon/asdf-java to manage Java versions (installed user-wide instead of system-wide), however, an error is being thrown due to `ChildProcess.exec` not being able to find Java.

Fixed the issue by using the `bin/java` inside the `$JAVA_HOME` directory.