### PR TITLE
fix: Setting CLASSPATH environment var doesn't crash extension

### DIFF
--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -25,6 +25,7 @@ import * as socket from './socket'
 const _ = require('lodash/fp')
 const ChildProcess = require('child_process')
 const portfinder = require('portfinder')
+const path = require('path')
 
 export interface CompileOnSave {
   enabled: boolean
@@ -107,7 +108,8 @@ export async function start (input: StartEngineInput) {
   // get a port starting from 8888
   const port = await portfinder.getPortPromise({ port: 8888 })
 
-  flixInstance = ChildProcess.spawn('java', ['-jar', flixFilename, '--lsp', port])
+  let classpath = (process.env.CLASSPATH || "") + path.delimiter + flixFilename
+  flixInstance = ChildProcess.spawn('java', ['-cp', classpath, 'ca.uwaterloo.flix.Main', '--lsp', port])
   const webSocketUrl = `ws://localhost:${port}`
 
   // forward flix to own stdout & stderr

--- a/server/src/util/javaVersion.ts
+++ b/server/src/util/javaVersion.ts
@@ -36,7 +36,8 @@ const getMajorVersion = _.flow(
 
 export default async function javaMajorVersion (rootPath: string): Promise<JavaVersion> {
   return new Promise((resolve) => {
-    ChildProcess.exec('java CheckJavaVersion', { cwd: path.join(rootPath, 'java') }, (error: any, stdout: any, stderror: any) => {
+    let cwd = path.join(rootPath, 'java');
+    ChildProcess.exec(`java -cp ${cwd} CheckJavaVersion`, { cwd:  cwd}, (error: any, stdout: any, stderror: any) => {
       if (error) {
         return resolve(unknownJavaVersion)
       }


### PR DESCRIPTION
The change in javaVersion.ts prevents the extension from crashing if CLASSPATH is set when VSCode is launched.

The change in flix.ts causes CLASSPATH to propagate to Flix (java -jar doesn't seem to respect CLASSPATH), but appends the Flix jar itself to the classpath so that the Flix compiler is available.