### PR TITLE
refactor "Run Main" to open a new terminal to compile the flix program

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -14,7 +14,7 @@ import initialiseState from './services/state'
 import * as handlers from './handlers'
 import { callResolversAndEmptyList } from './services/timers'
 
-export const _ = require('lodash/fp')
+const _ = require('lodash/fp')
 
 export interface LaunchOptions {
   shouldUpdateFlix: boolean

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -105,8 +105,9 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   // Register commands for command palette
   registerCommand('flix.internalRestart', makeHandleRestartClient(context, { shouldUpdateFlix: false }))
   registerCommand('flix.internalDownloadLatest', makeHandleRestartClient(context, { shouldUpdateFlix: true }))
-
-  registerCommand('flix.cmdRunMain', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunMain, 'Running Main'))
+  registerCommand('flix.cmdRunMain', handlers.compileInTerminal)
+  
+//   registerCommand('flix.cmdRunMain', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunMain, 'Running Main'))
   registerCommand('flix.cmdRunAllTests', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunTests, 'Running Tests'))
 
   // NOTE: Currently commented out as it is being worked on.
@@ -200,6 +201,7 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
 
   // Wait until we're sure flix exists
   const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+  handlers.setFlixFileName(flixFilename) 
 
   // Show a startup progress that times out after 10 (default) seconds
   showStartupProgress()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -105,7 +105,10 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   // Register commands for command palette
   registerCommand('flix.internalRestart', makeHandleRestartClient(context, { shouldUpdateFlix: false }))
   registerCommand('flix.internalDownloadLatest', makeHandleRestartClient(context, { shouldUpdateFlix: true }))
-  registerCommand('flix.cmdRunMain', handlers.compileInTerminal)
+  registerCommand('flix.cmdRunMain', handlers.RunInExistingTerminalWithoutArg)
+  registerCommand('flix.runMainWithArgs', handlers.RunInExistingTerminalWithArg)
+  registerCommand('flix.runMainNewTerminal', handlers.RunInNewTerminalWithoutArg)
+  registerCommand('flix.runMainNewTerminalWithArgs', handlers.RunInNewTerminalWithArg)
   
 //   registerCommand('flix.cmdRunMain', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunMain, 'Running Main'))
   registerCommand('flix.cmdRunAllTests', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunTests, 'Running Tests'))

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -14,13 +14,13 @@ import initialiseState from './services/state'
 import * as handlers from './handlers'
 import { callResolversAndEmptyList } from './services/timers'
 
-const _ = require('lodash/fp')
+export const _ = require('lodash/fp')
 
-interface LaunchOptions {
+export interface LaunchOptions {
   shouldUpdateFlix: boolean
 }
 
-const defaultLaunchOptions: LaunchOptions = {
+export const defaultLaunchOptions: LaunchOptions = {
   shouldUpdateFlix: false
 }
 
@@ -30,7 +30,7 @@ let flixWatcher: vscode.FileSystemWatcher
 
 const extensionObject = vscode.extensions.getExtension('flix.flix')
 
-const FLIX_GLOB_PATTERN = '**/*.flix'
+export const FLIX_GLOB_PATTERN = '**/*.flix'
 
 let outputChannel: vscode.OutputChannel
 
@@ -105,10 +105,10 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   // Register commands for command palette
   registerCommand('flix.internalRestart', makeHandleRestartClient(context, { shouldUpdateFlix: false }))
   registerCommand('flix.internalDownloadLatest', makeHandleRestartClient(context, { shouldUpdateFlix: true }))
-  registerCommand('flix.cmdRunMain', handlers.RunInExistingTerminalWithoutArg)
-  registerCommand('flix.runMainWithArgs', handlers.RunInExistingTerminalWithArg)
-  registerCommand('flix.runMainNewTerminal', handlers.RunInNewTerminalWithoutArg)
-  registerCommand('flix.runMainNewTerminalWithArgs', handlers.RunInNewTerminalWithArg)
+  registerCommand('flix.cmdRunMain', handlers.cmdRunMain(context, launchOptions))
+  registerCommand('flix.runMainWithArgs', handlers.runMainWithArgs(context, launchOptions))
+  registerCommand('flix.runMainNewTerminal', handlers.runMainNewTerminal(context, launchOptions))
+  registerCommand('flix.runMainNewTerminalWithArgs', handlers.runMainNewTerminalWithArgs(context, launchOptions))
   
 //   registerCommand('flix.cmdRunMain', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunMain, 'Running Main'))
   registerCommand('flix.cmdRunAllTests', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunTests, 'Running Tests'))
@@ -204,7 +204,6 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
 
   // Wait until we're sure flix exists
   const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-  handlers.setFlixFileName(flixFilename) 
 
   // Show a startup progress that times out after 10 (default) seconds
   showStartupProgress()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -109,8 +109,6 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   registerCommand('flix.runMainWithArgs', handlers.runMainWithArgs(context, launchOptions))
   registerCommand('flix.runMainNewTerminal', handlers.runMainNewTerminal(context, launchOptions))
   registerCommand('flix.runMainNewTerminalWithArgs', handlers.runMainNewTerminalWithArgs(context, launchOptions))
-  
-//   registerCommand('flix.cmdRunMain', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunMain, 'Running Main'))
   registerCommand('flix.cmdRunAllTests', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunTests, 'Running Tests'))
 
   // NOTE: Currently commented out as it is being worked on.

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
+import { quote } from 'shell-quote';
 
 import * as jobs from '../engine/jobs'
 import * as timers from '../services/timers'
@@ -92,7 +93,7 @@ async function takeInputFromUser() {
 async function getFiles() {
     const files = await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)
     let paths = files.map(x => x.path)
-    let cmd = require('shell-quote').quote(paths)
+    let cmd = quote(paths)
     return cmd
 }
 
@@ -110,7 +111,7 @@ async function passArgs(terminal:vscode.Terminal, flixFilename: string) {
     let input = await takeInputFromUser()
     if(input != undefined) {
         cmd += " --args ";
-        cmd += require('shell-quote').quote([input]);
+        cmd += quote([input]);
         passCommandToTerminal(cmd, terminal)  
     }
 }
@@ -134,7 +135,7 @@ export function cmdRunMain(
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
             const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            var flixFilename = require('shell-quote').quote([flixFileLocation])
+            var flixFilename = quote([flixFileLocation])
             let cmd = "java -jar "+ flixFilename + " "
             cmd += await getFiles()
             let terminal = ensureFlixTerminal()
@@ -161,7 +162,7 @@ export function runMainWithArgs(
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
             const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            var flixFilename = require('shell-quote').quote([flixFileLocation])
+            var flixFilename = quote([flixFileLocation])
             
             let terminal = ensureFlixTerminal()
             await passArgs(terminal, flixFilename)
@@ -187,7 +188,7 @@ export function runMainNewTerminal(
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
             const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            var flixFilename = require('shell-quote').quote([flixFileLocation])
+            var flixFilename = quote([flixFileLocation])
             
             let terminal = ensureNewFlixTerminal()
             let cmd = "java -jar "+ flixFilename + " "
@@ -216,7 +217,7 @@ export function runMainNewTerminalWithArgs(
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
             const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            var flixFilename = require('shell-quote').quote([flixFileLocation])
+            var flixFilename = quote([flixFileLocation])
 
             let terminal = ensureNewFlixTerminal()
             await passArgs(terminal, flixFilename)

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -91,10 +91,8 @@ async function takeInputFromUser() {
 */
 async function getFiles() {
     const files = await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)
-    let cmd = ""
-    for (const file of files) {
-        cmd += " \""+file.path+"\"";
-    }
+    let paths = files.map(x => x.path)
+    let cmd = require('shell-quote').quote(paths)
     return cmd
 }
 
@@ -107,13 +105,12 @@ async function getFiles() {
 */
 async function passArgs(terminal:vscode.Terminal, flixFilename: string) {
 
-    let cmd = "java -jar \""+ flixFilename + "\""
+    let cmd = "java -jar "+ flixFilename + " "
     cmd += await getFiles()
     let input = await takeInputFromUser()
     if(input != undefined) {
-        cmd += " --args \"";
-        cmd += input;
-        cmd += "\""
+        cmd += " --args ";
+        cmd += require('shell-quote').quote([input]);
         passCommandToTerminal(cmd, terminal)  
     }
 }
@@ -136,9 +133,9 @@ export function cmdRunMain(
         return async function handler () {
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            
-            let cmd = "java -jar \""+ flixFilename + "\""
+            const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+            var flixFilename = require('shell-quote').quote([flixFileLocation])
+            let cmd = "java -jar "+ flixFilename + " "
             cmd += await getFiles()
             let terminal = ensureFlixTerminal()
             passCommandToTerminal(cmd, terminal)  
@@ -163,7 +160,8 @@ export function runMainWithArgs(
         return async function handler () {
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+            const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+            var flixFilename = require('shell-quote').quote([flixFileLocation])
             
             let terminal = ensureFlixTerminal()
             await passArgs(terminal, flixFilename)
@@ -188,10 +186,11 @@ export function runMainNewTerminal(
         return async function handler () {
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+            const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+            var flixFilename = require('shell-quote').quote([flixFileLocation])
             
             let terminal = ensureNewFlixTerminal()
-            let cmd = "java -jar \""+ flixFilename + "\""
+            let cmd = "java -jar "+ flixFilename + " "
             cmd += await getFiles()
             passCommandToTerminal(cmd, terminal)
         }
@@ -216,8 +215,9 @@ export function runMainNewTerminalWithArgs(
         return async function handler () {
             const globalStoragePath = context.globalStoragePath
             const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            
+            const flixFileLocation = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+            var flixFilename = require('shell-quote').quote([flixFileLocation])
+
             let terminal = ensureNewFlixTerminal()
             await passArgs(terminal, flixFilename)
         }

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -109,11 +109,11 @@ async function passArgs(terminal:vscode.Terminal, flixFilename: string) {
     let cmd = "java -jar "+ flixFilename + " "
     cmd += await getFiles()
     let input = await takeInputFromUser()
-    if(input != undefined) {
+    if(!(input == undefined || input.trim().length == 0)) {
         cmd += " --args ";
         cmd += quote([input]);
-        passCommandToTerminal(cmd, terminal)  
     }
+    passCommandToTerminal(cmd, terminal)  
 }
 
 /**

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -7,6 +7,8 @@ import eventEmitter from '../services/eventEmitter'
 import ensureFlixExists from './../util/ensureFlixExists'
 import { LaunchOptions, defaultLaunchOptions, FLIX_GLOB_PATTERN, _ } from './../extension'
 
+let countTerminals:number = 0
+
 export function makeHandleRunJob (
   client: LanguageClient,
   request: jobs.Request
@@ -14,21 +16,6 @@ export function makeHandleRunJob (
   return function handler () {
     client.sendNotification(request)
   }
-}
-
-/**
- * returns a count of total active terminals with prefix name `flix`.
- * 
- * @return number
-*/
-function countFlixTerminals() {
-    const activeTerminals = vscode.window.terminals
-    let count = 0
-    for (const element of activeTerminals) {
-        if(element.name.substring(0, 4) == `flix`)
-            count+=1
-    }
-    return count
 }
 
 /**
@@ -44,7 +31,9 @@ function ensureFlixTerminal() {
         if(element.name.substring(0, 4) == `flix`)
             return element
     }
-    return vscode.window.createTerminal(`flix-0`);
+    const terminal = vscode.window.createTerminal(`flix-`+countTerminals.toString());
+    countTerminals+=1 //creating a new terminal since no active flix terminals available.
+    return terminal
 }
 
 
@@ -58,8 +47,9 @@ function ensureFlixTerminal() {
  * @return vscode.Terminal
 */
 function ensureNewFlixTerminal() {
-    const count = countFlixTerminals()
-    return vscode.window.createTerminal(`flix-`+count.toString())
+    const terminal = vscode.window.createTerminal(`flix-`+countTerminals.toString())
+    countTerminals+=1
+    return terminal
 }
 
 /**

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -94,7 +94,7 @@ async function takeInputFromUser() {
 */
 async function getFiles() {
     const files = await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)
-    return files.map(x => x.path)
+    return files.map(x => x.fsPath)
 }
 
 /**

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -17,10 +17,22 @@ export function makeHandleRunJob (
 let flixFileLocation
 const FLIX_GLOB_PATTERN = '**/*.flix'
 
+/**
+ * It sets the path of flix.jar to a local variable `flixFileLocation` in file `handlers.ts`.
+ * 
+ * @param Filename String (path of the flix.jar)
+ * 
+ * @return void
+*/
 export function setFlixFileName(Filename:String) {
     flixFileLocation = Filename
 }
 
+/**
+ * returns a count of total active terminals with prefix name `flix`.
+ * 
+ * @return number
+*/
 function countFlixTerminals() {
     const activeTerminals = vscode.window.terminals
     let count = 0
@@ -32,6 +44,13 @@ function countFlixTerminals() {
     return count
 }
 
+/**
+ * returns an active terminal with prefix name `flix`.
+ * 
+ * If not any active terminal with prefix name `flix`, it creates a new terminal with name `flix`.
+ *
+ * @return vscode.Terminal
+*/
 function ensureFlixTerminal() {
     const activeTerminals = vscode.window.terminals
     for (let i = 0; i < activeTerminals.length; i++) {
@@ -42,6 +61,16 @@ function ensureFlixTerminal() {
     return vscode.window.createTerminal(`flix`);
 }
 
+
+/**
+ * returns an new active terminal with prefix name `flix`.
+ * 
+ * If not any active terminal with prefix name `flix`, it creates a new terminal with name `flix` and returns it.
+ *
+ * If there are already `n` active terminals exist with prefix name `flix`, it creates a new terminal with name `flix n+1`
+ *
+ * @return vscode.Terminal
+*/
 function ensureNewFlixTerminal() {
     const count = countFlixTerminals()
     if(count == 0)
@@ -49,11 +78,27 @@ function ensureNewFlixTerminal() {
     else return vscode.window.createTerminal(`flix `+(count+1).toString())
 }
 
+/**
+ * takes a string and a terminal and passes that string to the terminal.
+ *
+ * @param cmd string (a terminal command) to pass to the terminal.
+ *
+ * @param terminal vscode.Terminal 
+ *
+ * @return void
+*/
 function passCommandToTerminal(cmd:string, terminal: vscode.Terminal) {
     terminal.show();
     terminal.sendText(cmd);
 }
 
+/**
+ * Opens an input box to ask the user for input.
+ * uses the `vscode.window.showInputBox` function with custom `prompt` and `placeHolder` and value of `ignoreFocusOut` to be `true`.
+ *
+ *
+ * @return A promise that resolves to a string the user provided or to `undefined` in case of dismissal.
+*/
 async function takeInputFromUser() {
     const input = await vscode.window.showInputBox({
         prompt: "Enter the space separated arguments",
@@ -63,6 +108,13 @@ async function takeInputFromUser() {
     return input
 }
 
+/**
+ * combines the paths of all flix files present in the current directory of vscode window.
+ * 
+ * gets an array of vscode.Uri for all flix files using `vscode.workspace.findFiles` function
+ *
+ * @return string of format "\<path_to_first_file\>" "\<path_to_second_file\>" ..........
+*/
 async function getFiles() {
     const files = await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)
     let cmd = ""
@@ -71,6 +123,13 @@ async function getFiles() {
     return cmd
 }
 
+/**
+ * sends a java command to compile and run flix program of vscode window to the terminal.
+ *
+ * @param terminal vscode.Terminal to receive the command. 
+ *
+ * @return void
+*/
 async function passArgs(terminal:vscode.Terminal) {
     let cmd = "java -jar "+flixFileLocation
     cmd += await getFiles()
@@ -86,6 +145,13 @@ async function passArgs(terminal:vscode.Terminal) {
     }
 }
 
+/**
+ * Run main without any custom arguments
+ * 
+ * Sends command `java -jar <path_to_flix.jar> <paths_to_all_flix_files>` to an existing (if already exists else new) terminal.
+ * 
+ * @return void
+*/
 export async function RunInExistingTerminalWithoutArg() {
     let terminal = ensureFlixTerminal()
     let cmd = "java -jar "+flixFileLocation
@@ -93,6 +159,13 @@ export async function RunInExistingTerminalWithoutArg() {
     passCommandToTerminal(cmd, terminal)  
 }
 
+/**
+ * Run main without any custom arguments in a new terminal
+ * 
+ * Sends command `java -jar <path_to_flix.jar> <paths_to_all_flix_files>` to a new terminal.
+ * 
+ * @return void
+*/
 export async function RunInNewTerminalWithoutArg() {
     let terminal = ensureNewFlixTerminal()
     let cmd = "java -jar "+flixFileLocation
@@ -100,11 +173,25 @@ export async function RunInNewTerminalWithoutArg() {
     passCommandToTerminal(cmd, terminal)
 }
 
+/**
+ * Run main with user provided arguments
+ * 
+ * Sends command `java -jar <path_to_flix.jar> <paths_to_all_flix_files> --args <arguments>` to an existing (if already exists else new) terminal.
+ * 
+ * @return void
+*/
 export async function RunInExistingTerminalWithArg() {
     let terminal = ensureFlixTerminal()
     await passArgs(terminal)
 }
 
+/**
+ * Run main with user provided arguments in a new terminal
+ * 
+ * Sends command `java -jar <path_to_flix.jar> <paths_to_all_flix_files> --args <arguments>` to a new terminal.
+ * 
+ * @return void
+*/
 export async function RunInNewTerminalWithArg() {
     let terminal = ensureNewFlixTerminal()
     await passArgs(terminal)

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -116,6 +116,22 @@ async function passArgs(terminal:vscode.Terminal, flixFilename: string) {
 }
 
 /**
+ * It takes context and launchOptions as arguments and finds the path of `flix.jar`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LauchOptions
+ * 
+ * @returns string (path of `flix.jar`)
+ */
+async function getFlixFilename(context:vscode.ExtensionContext, launchOptions: LaunchOptions) {
+    const globalStoragePath = context.globalStoragePath
+    const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
+    return await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+}
+
+
+/**
  * Run main without any custom arguments
  * 
  * Sends command `java -jar <path_to_flix.jar> <paths_to_all_flix_files>` to an existing (if already exists else new) terminal.
@@ -131,10 +147,7 @@ export function cmdRunMain(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const globalStoragePath = context.globalStoragePath
-            const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-
+            const flixFilename = await getFlixFilename(context, launchOptions)
             let cmd = ['java', '-jar', flixFilename]
             cmd.push(...await getFiles())
             let terminal = getFlixTerminal()
@@ -158,10 +171,7 @@ export function runMainWithArgs(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const globalStoragePath = context.globalStoragePath
-            const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            
+            const flixFilename = await getFlixFilename(context, launchOptions)
             let terminal = getFlixTerminal()
             await passArgs(terminal, flixFilename)
         }
@@ -183,10 +193,7 @@ export function runMainNewTerminal(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const globalStoragePath = context.globalStoragePath
-            const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-            
+            const flixFilename = await getFlixFilename(context, launchOptions)
             let terminal = newFlixTerminal()
             let cmd = ['java', '-jar', flixFilename]
             cmd.push(...await getFiles())
@@ -211,10 +218,7 @@ export function runMainNewTerminalWithArgs(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const globalStoragePath = context.globalStoragePath
-            const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
-            const flixFilename = await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
-
+            const flixFilename = await getFlixFilename(context, launchOptions)
             let terminal = newFlixTerminal()
             await passArgs(terminal, flixFilename)
         }

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -14,6 +14,86 @@ export function makeHandleRunJob (
   }
 }
 
+let flixFileLocation
+const FLIX_GLOB_PATTERN = '**/*.flix'
+
+export function setFlixFileName(Filename:String) {
+    flixFileLocation = Filename
+}
+
+function selectTerminal(): Thenable<vscode.Terminal | undefined> {
+	interface TerminalQuickPickItem extends vscode.QuickPickItem {
+		terminal: vscode.Terminal;
+	}
+	const terminals = <vscode.Terminal[]>(<any>vscode.window).terminals;
+	let items: TerminalQuickPickItem[] = terminals.map(t => {
+		return {
+			label: `name: ${t.name}`,
+			terminal: t
+		};
+	});
+    items.push({label:`create a new terminal`, terminal: undefined})
+	return vscode.window.showQuickPick(items).then(item => {
+		return item ? item.terminal : undefined;
+	});
+}
+
+function findFlixTerminal() {
+    const activeTerminals = vscode.window.terminals
+    for (let i = 0; i < activeTerminals.length; i++) {
+        const element = activeTerminals[i];
+        if(element.name == `flix`)
+            return element
+    }
+    return undefined
+}
+
+function showActiveTerminals() {
+    const activeTerminals = vscode.window.terminals
+    for (let i = 0; i < activeTerminals.length; i++) {
+        const element = activeTerminals[i];
+        console.log(element)
+    }
+}
+
+export async function compileInTerminal() {
+    
+    const files = await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)
+    let cmd = "java -jar "+flixFileLocation;
+    for (let index = 0; index < files.length ; index++)
+        cmd += " "+files[index].path;
+
+    // method 1
+    // let ter = findFlixTerminal()
+    // if(!ter)
+    // {
+    //     ter = vscode.window.createTerminal({name: 'flix'});   
+    // }
+    // ter.show()
+    // ter.sendText(cmd)
+
+    // method 2
+    if(vscode.window.terminals.length == 0) //no terminals active
+    {
+        let newterminal = vscode.window.createTerminal({name:`flix`, hideFromUser: false})
+        newterminal.show()
+        newterminal.sendText(cmd)
+    }
+    else { //select one terminal from drop down window
+        selectTerminal().then(terminal => {
+            if(terminal) {
+                terminal.show()
+                terminal.sendText(cmd)
+            }
+            else { //if user choose `create a new terminal`
+                let newterminal = vscode.window.createTerminal({name:`flix`, hideFromUser: false})
+                newterminal.show()
+                newterminal.sendText(cmd)
+            }
+        })
+    }
+}
+
 export function makeHandleRunJobWithProgress (
   client: LanguageClient, 
   outputChannel: vscode.OutputChannel, 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,18 @@
         "title": "Flix: Run Main"
       },
       {
+        "command": "flix.runMainWithArgs",
+        "title": "Flix: Run Main with args"
+      },
+      {
+        "command": "flix.runMainNewTerminal",
+        "title": "Flix: Run Main (New Terminal) "
+      },
+      {
+        "command": "flix.runMainNewTerminalWithArgs",
+        "title": "Flix: Run Main with args (New Terminal)"
+      },
+      {
         "command": "flix.cmdRunAllTests",
         "title": "Flix: Run Tests"
       }

--- a/package.json
+++ b/package.json
@@ -115,5 +115,8 @@
     "eslint": "^7.28.0",
     "mocha": "^9.0.0",
     "typescript": "^4.3.4"
+  },
+  "dependencies": {
+    "shell-quote": "^1.7.2"
   }
 }


### PR DESCRIPTION
fix #102 

For now, two methods are added:
Method 1: It simply checks whether there is an active terminal with the name `flix` in vscode window. If no, then it creates a new terminal named `flix` and compiles the flix program in that terminal. else it compiles in the existing terminal with the name `flix`.

Method 2: If there are no active terminals, it simply creates a new terminal named `flix` and compiles the program in it. If there are active terminals, then it opens a drop-down window in vscode to select a terminal to compile.
a sample drop-down to select a terminal:
![Screenshot from 2021-06-18 10-01-17](https://user-images.githubusercontent.com/45541010/122507586-15e72c00-d01e-11eb-8e0a-d59be9e83bde.png)
