### PR TITLE
add package commands and run in a new terminal

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -118,7 +118,7 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   registerCommand('flix.cmdRunProject', handlers.cmdRunProject(context, launchOptions))
   registerCommand('flix.cmdBenchmark', handlers.cmdBenchmark(context, launchOptions))
   registerCommand('flix.cmdTests', handlers.cmdTests(context, launchOptions))
-  registerCommand('flix.cmdTestWithFiler', handlers.cmdTestWithFilter(context, launchOptions))
+  registerCommand('flix.cmdTestWithFilter', handlers.cmdTestWithFilter(context, launchOptions))
   
   // watch for changes on the file system (delete, create, rename .flix files)
   flixWatcher = vscode.workspace.createFileSystemWatcher(FLIX_GLOB_PATTERN)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -118,7 +118,7 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   registerCommand('flix.cmdRunProject', handlers.cmdRunProject(context, launchOptions))
   registerCommand('flix.cmdBenchmark', handlers.cmdBenchmark(context, launchOptions))
   registerCommand('flix.cmdTests', handlers.cmdTests(context, launchOptions))
-  registerCommand('flix.cmdTest', handlers.cmdTest(context, launchOptions))
+  registerCommand('flix.cmdTestWithFiler', handlers.cmdTestWithFilter(context, launchOptions))
   
   // watch for changes on the file system (delete, create, rename .flix files)
   flixWatcher = vscode.workspace.createFileSystemWatcher(FLIX_GLOB_PATTERN)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -109,8 +109,17 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   registerCommand('flix.runMainWithArgs', handlers.runMainWithArgs(context, launchOptions))
   registerCommand('flix.runMainNewTerminal', handlers.runMainNewTerminal(context, launchOptions))
   registerCommand('flix.runMainNewTerminalWithArgs', handlers.runMainNewTerminalWithArgs(context, launchOptions))
-  registerCommand('flix.cmdRunAllTests', handlers.makeHandleRunJobWithProgress(client, outputChannel, jobs.Request.cmdRunTests, 'Running Tests'))
-
+  
+  registerCommand('flix.cmdInit', handlers.cmdInit(context, launchOptions))
+  registerCommand('flix.cmdCheck', handlers.cmdCheck(context, launchOptions))
+  registerCommand('flix.cmdBuild', handlers.cmdBuild(context, launchOptions))
+  registerCommand('flix.cmdBuildJar', handlers.cmdBuildJar(context, launchOptions))
+  registerCommand('flix.cmdBuildPkg', handlers.cmdBuildPkg(context, launchOptions))
+  registerCommand('flix.cmdRunProject', handlers.cmdRunProject(context, launchOptions))
+  registerCommand('flix.cmdBenchmark', handlers.cmdBenchmark(context, launchOptions))
+  registerCommand('flix.cmdTests', handlers.cmdTests(context, launchOptions))
+  registerCommand('flix.cmdTest', handlers.cmdTest(context, launchOptions))
+  
   // watch for changes on the file system (delete, create, rename .flix files)
   flixWatcher = vscode.workspace.createFileSystemWatcher(FLIX_GLOB_PATTERN)
   flixWatcher.onDidDelete((vsCodeUri: vscode.Uri) => {

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -473,7 +473,7 @@ export function cmdTestWithFilter(
             })
             if(input != undefined)
             {
-                cmd.push(...input.split(' '))
+                cmd.push(input)
                 let terminal = getTerminal('testWithFilter')
                 passCommandToTerminal(cmd, terminal)
             }

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -260,3 +260,202 @@ export function makeHandleRunJobWithProgress (
     })
   }
 }
+
+/**
+ * creates a new project in the current directory using command `java -jar flix.jar init`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+ export function cmdInit(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'init']
+            let terminal = vscode.window.createTerminal({name: `init`})
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * checks the current project for errors using command `java -jar flix.jar check`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+
+export function cmdCheck(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'check']
+            let terminal = vscode.window.createTerminal({name: `check`})
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * builds (i.e. compiles) the current project using command `java -jar flix.jar build`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdBuild(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'build']
+            let terminal = vscode.window.createTerminal({name: 'build'})
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * builds a jar-file from the current project using command `java -jar flix.jar build-jar`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdBuildJar(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'build-jar']
+            let terminal = vscode.window.createTerminal({name: 'build-jar'})
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * builds a fpkg-file from the current project using command `java -jar flix.jar build-pkg`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdBuildPkg(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'build-pkg']
+            let terminal = vscode.window.createTerminal({name: 'build-pkg'})
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * runs main for the current project using command `java -jar flix.jar run`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdRunProject(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'run']
+            let terminal = vscode.window.createTerminal('run')
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * runs the benchmarks for the current project using command `java -jar flix.jar benchmark`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdBenchmark(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'benchmark']
+            let terminal = vscode.window.createTerminal({name: 'benchmark'})
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * runs all the tests for the current project using command `java -jar flix.jar test`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdTests(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'test']
+            let terminal = vscode.window.createTerminal('tests')
+            passCommandToTerminal(cmd, terminal)
+        }
+}
+
+/**
+ * runs the custom tests for the current project using command `java -jar flix.jar test <test01> <test02> ...`
+ * 
+ * @param context vscode.ExtensionContext
+ * 
+ * @param launchOptions LaunchOptions
+ * 
+ * @returns function handler
+ */
+export function cmdTest(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        return async function handler () {
+            const flixFilename = await getFlixFilename(context, launchOptions)
+            const cmd = ['java', '-jar', flixFilename, 'test']
+            const input = await vscode.window.showInputBox({
+                prompt: "Enter names of test functions separated by spaces",
+                placeHolder: "test01 test02 ...",
+                ignoreFocusOut: true
+            })
+            if(input != undefined)
+            {
+                cmd.push(...input.split(' '))
+                let terminal = vscode.window.createTerminal('test')
+                passCommandToTerminal(cmd, terminal)
+            }
+        }
+}

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -261,6 +261,26 @@ export function makeHandleRunJobWithProgress (
   }
 }
 
+
+/**
+ * Returns a terminal with the given name (new if already not exists)
+ * 
+ * @param name name of the terminal
+ * 
+ * @returns vscode.Terminal
+ */
+
+function getTerminal(name: string) {
+    const activeTerminals = vscode.window.terminals
+    for (const element of activeTerminals) {
+        if(element.name == name)
+            return element
+    }
+    return vscode.window.createTerminal({name: name})
+}
+
+
+
 /**
  * creates a new project in the current directory using command `java -jar flix.jar init`
  * 
@@ -277,7 +297,7 @@ export function makeHandleRunJobWithProgress (
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'init']
-            let terminal = vscode.window.createTerminal({name: `init`})
+            let terminal = getTerminal('init')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -299,7 +319,7 @@ export function cmdCheck(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'check']
-            let terminal = vscode.window.createTerminal({name: `check`})
+            let terminal = getTerminal('check')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -320,7 +340,7 @@ export function cmdBuild(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'build']
-            let terminal = vscode.window.createTerminal({name: 'build'})
+            let terminal = getTerminal('build')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -341,7 +361,7 @@ export function cmdBuildJar(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'build-jar']
-            let terminal = vscode.window.createTerminal({name: 'build-jar'})
+            let terminal = getTerminal('build-jar')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -362,7 +382,7 @@ export function cmdBuildPkg(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'build-pkg']
-            let terminal = vscode.window.createTerminal({name: 'build-pkg'})
+            let terminal = getTerminal('build-pkg')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -383,7 +403,7 @@ export function cmdRunProject(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'run']
-            let terminal = vscode.window.createTerminal('run')
+            let terminal = getTerminal('run')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -404,7 +424,7 @@ export function cmdBenchmark(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'benchmark']
-            let terminal = vscode.window.createTerminal({name: 'benchmark'})
+            let terminal = getTerminal('benchmark')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -425,7 +445,7 @@ export function cmdTests(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'test']
-            let terminal = vscode.window.createTerminal('tests')
+            let terminal = getTerminal('test')
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -439,7 +459,7 @@ export function cmdTests(
  * 
  * @returns function handler
  */
-export function cmdTest(
+export function cmdTestWithFilter(
     context: vscode.ExtensionContext, 
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
@@ -454,7 +474,7 @@ export function cmdTest(
             if(input != undefined)
             {
                 cmd.push(...input.split(' '))
-                let terminal = vscode.window.createTerminal('test')
+                let terminal = getTerminal('testWithFilter')
                 passCommandToTerminal(cmd, terminal)
             }
         }

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
         "title": "Flix: run all tests"
       },
       {
-        "command": "flix.cmdTest",
-        "title": "Flix: run custom tests"
+        "command": "flix.cmdTestWithFilter",
+        "title": "Flix: run tests (with filter)"
       }
     ],
     "languages": [

--- a/package.json
+++ b/package.json
@@ -49,8 +49,40 @@
         "title": "Flix: Run with args ... (in new terminal)"
       },
       {
-        "command": "flix.cmdRunAllTests",
-        "title": "Flix: Run Tests"
+        "command": "flix.cmdInit",
+        "title": "Flix: init"
+      },
+      {
+        "command": "flix.cmdCheck",
+        "title": "Flix: check"
+      },
+      {
+        "command": "flix.cmdBuild",
+        "title": "Flix: build"
+      },
+      {
+        "command": "flix.cmdBuildJar",
+        "title": "Flix: build-jar"
+      },
+      {
+        "command": "flix.cmdBuildPkg",
+        "title": "Flix: build-pkg"
+      },
+      {
+        "command": "flix.cmdRunProject",
+        "title": "Flix: run project"
+      },
+      {
+        "command": "flix.cmdBenchmark",
+        "title": "Flix: run benchmark"
+      },
+      {
+        "command": "flix.cmdTests",
+        "title": "Flix: run all tests"
+      },
+      {
+        "command": "flix.cmdTest",
+        "title": "Flix: run custom tests"
       }
     ],
     "languages": [


### PR DESCRIPTION
flix #103 

The following package commands are added:
1. init: `java -jar flix.jar init`
2. check: `java -jar flix.jar check`
3. build: `java -jar flix.jar build`
4. build-jar: `java -jar flix.jar build-jar`
5. build-pkg: `java -jar flix.jar build-pkg`
6. run: `java -jar flix.jar run`
7. benchmark: `java -jar flix.jar benchmark`
8. tests: `java -jar flix.jar test`
9. custom tests: `java -jar flix.jar test test01 test02 ...`
where `flix.jar` means the location of `flix.jar` file. and the input in custom tests is taken from the user.