### PR TITLE
Add Support for addPkg and RemPkg

### DIFF
--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -26,6 +26,8 @@
 export enum Request {
   apiAddUri = 'api/addUri',
   apiRemUri = 'api/remUri',
+  apiAddPkg = 'api/addPkg',
+  apiRemPkg = 'api/remPkg',
   apiVersion = 'api/version',
   apiShutdown = 'api/shutdown',
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -28,9 +28,13 @@ let client: LanguageClient
 
 let flixWatcher: vscode.FileSystemWatcher
 
+let pkgWatcher: vscode.FileSystemWatcher
+
 const extensionObject = vscode.extensions.getExtension('flix.flix')
 
 export const FLIX_GLOB_PATTERN = '**/*.flix'
+
+const FPKG_GLOB_PATTERN = '**/lib/**/*.fpkg'
 
 let outputChannel: vscode.OutputChannel
 
@@ -122,6 +126,18 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
     client.sendNotification(jobs.Request.apiAddUri, { uri })
   })
 
+  // watch for changes on the file system (delete, create .fpkg files)
+  pkgWatcher = vscode.workspace.createFileSystemWatcher(FPKG_GLOB_PATTERN)
+  pkgWatcher.onDidDelete((vsCodeUri: vscode.Uri) => {
+    const uri = vsCodeUriToUriString(vsCodeUri)
+    client.sendNotification(jobs.Request.apiRemPkg, { uri })
+  })
+  pkgWatcher.onDidCreate((vsCodeUri: vscode.Uri) => {
+    const uri = vsCodeUriToUriString(vsCodeUri)
+    client.sendNotification(jobs.Request.apiAddPkg, { uri })
+  })
+  
+
   vscode.workspace.onDidChangeConfiguration(() => {
     client.sendNotification(jobs.Request.internalReplaceConfiguration, getUserConfiguration())
   })
@@ -143,6 +159,7 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
   const globalStoragePath = context.globalStoragePath
   const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
   const workspaceFiles: [string] = _.map(vsCodeUriToUriString, (await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)))
+  const workspacePkgs: [string] = _.map(vsCodeUriToUriString, (await vscode.workspace.findFiles(FPKG_GLOB_PATTERN)))
 
   // Make sure we can write to `./target`
   if (!ensureTargetWritable(_.first(workspaceFolders))) {
@@ -163,6 +180,7 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
     extensionVersion: extensionObject.packageJSON.version,
     globalStoragePath: context.globalStoragePath,
     workspaceFiles,
+    workspacePkgs,
     userConfiguration: getUserConfiguration()
   })
 
@@ -188,6 +206,7 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
 
 export function deactivate (): Thenable<void> | undefined {
   flixWatcher && flixWatcher.dispose()
+  pkgWatcher && pkgWatcher.dispose()
   outputChannel && outputChannel.dispose()
   diagnosticsOutputChannel && diagnosticsOutputChannel.dispose()
   return client ? client.stop() : undefined

--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -47,6 +47,7 @@ export interface StartEngineInput {
   extensionVersion: string,
   globalStoragePath: string,
   workspaceFiles: [string],
+  workspacePkgs: [string],
   userConfiguration: UserConfiguration
 }
 
@@ -95,7 +96,7 @@ export async function start (input: StartEngineInput) {
   // copy input to local var for later use
   startEngineInput = _.clone(input)
 
-  const { flixFilename, extensionPath, workspaceFiles } = input
+  const { flixFilename, extensionPath, workspaceFiles, workspacePkgs } = input
 
   // Check for valid Java version
   const { majorVersion, versionString } = await javaVersion(extensionPath)
@@ -122,7 +123,10 @@ export async function start (input: StartEngineInput) {
         uri: webSocketUrl,
         onOpen: function handleOpen () {
           flixRunning = true
-          queue.initialiseQueues(_.map((uri: string) => ({ uri, request: jobs.Request.apiAddUri }), workspaceFiles))
+          let jobArray = _.map((uri: string) => ({ uri, request: jobs.Request.apiAddUri }), workspaceFiles)
+          let pkgJobs = _.map((uri: string) => ({ uri, request: jobs.Request.apiAddPkg }), workspacePkgs)
+          jobArray.push(...pkgJobs)
+          queue.initialiseQueues(jobArray)
           handleVersion()
         },
         onClose: function handleClose () {
@@ -161,6 +165,22 @@ export function remUri (uri: string) {
   }
   queue.enqueue(job)
 }
+
+export function addPkg (uri: string) {
+    const job: jobs.Job = {
+      request: jobs.Request.apiAddPkg,
+      uri
+    }
+    queue.enqueue(job)
+  }
+  
+  export function remPkg (uri: string) {
+    const job: jobs.Job = {
+      request: jobs.Request.apiRemPkg,
+      uri
+    }
+    queue.enqueue(job)
+  }
 
 export function enqueueJobWithPosition (request: jobs.Request, params?: any) {
   const job: jobs.Job = {

--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -123,10 +123,12 @@ export async function start (input: StartEngineInput) {
         uri: webSocketUrl,
         onOpen: function handleOpen () {
           flixRunning = true
-          let jobArray = _.map((uri: string) => ({ uri, request: jobs.Request.apiAddUri }), workspaceFiles)
-          let pkgJobs = _.map((uri: string) => ({ uri, request: jobs.Request.apiAddPkg }), workspacePkgs)
-          jobArray.push(...pkgJobs)
-          queue.initialiseQueues(jobArray)
+          let addUriJobs = _.map((uri: string) => ({ uri, request: jobs.Request.apiAddUri }), workspaceFiles)
+          let addPkgJobs = _.map((uri: string) => ({ uri, request: jobs.Request.apiAddPkg }), workspacePkgs)
+          let Jobs:any = []
+          Jobs.push(...addUriJobs)
+          Jobs.push(...addPkgJobs)
+          queue.initialiseQueues(Jobs)
           handleVersion()
         },
         onClose: function handleClose () {
@@ -167,20 +169,20 @@ export function remUri (uri: string) {
 }
 
 export function addPkg (uri: string) {
-    const job: jobs.Job = {
-      request: jobs.Request.apiAddPkg,
-      uri
-    }
-    queue.enqueue(job)
+  const job: jobs.Job = {
+    request: jobs.Request.apiAddPkg,
+    uri
   }
+  queue.enqueue(job)
+}
   
-  export function remPkg (uri: string) {
-    const job: jobs.Job = {
-      request: jobs.Request.apiRemPkg,
-      uri
-    }
-    queue.enqueue(job)
+export function remPkg (uri: string) {
+  const job: jobs.Job = {
+    request: jobs.Request.apiRemPkg,
+    uri
   }
+  queue.enqueue(job)
+}
 
 export function enqueueJobWithPosition (request: jobs.Request, params?: any) {
   const job: jobs.Job = {

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -26,6 +26,8 @@
 export enum Request {
   apiAddUri = 'api/addUri',
   apiRemUri = 'api/remUri',
+  apiAddPkg = 'api/addPkg',
+  apiRemPkg = 'api/remPkg',
   apiVersion = 'api/version',
   apiShutdown = 'api/shutdown',
 
@@ -59,6 +61,7 @@ export interface Job {
   request: Request
   uri?: string
   src?: string
+  base64?: string
   position?: Position
   projectRootUri?: string
   newName?: string

--- a/server/src/engine/queue.ts
+++ b/server/src/engine/queue.ts
@@ -34,7 +34,8 @@ let waitingForPriorityQueue: jobs.JobMap = {
 }
 
 function isPriorityJob (job: jobs.Job) {
-  return job.request === jobs.Request.apiAddUri || job.request === jobs.Request.apiRemUri
+  return (job.request === jobs.Request.apiAddUri || job.request === jobs.Request.apiRemUri 
+    || job.request == jobs.Request.apiAddPkg || job.request == jobs.Request.apiRemPkg)
 }
 
 function jobToEnqueuedJob (job: jobs.Job) {
@@ -169,6 +170,9 @@ export async function processQueue () {
       if (job.request === jobs.Request.apiAddUri && !job.src) {
         const src = fs.readFileSync(fileURLToPath(job.uri!), 'utf8')
         socket.sendMessage({ ...job, src })
+      } else if(job.request == jobs.Request.apiAddPkg && !job.src) {
+        const base64 = fs.readFileSync(fileURLToPath(job.uri!)).toString('base64')
+        socket.sendMessage({...job, base64 })
       } else {
         socket.sendMessage(job)
       }

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -74,16 +74,16 @@ export function handleAddUri ({ uri }: UriInput) {
 }
 
 export function handleRemUri ({ uri }: UriInput) {
-    engine.remUri(uri)
+  engine.remUri(uri)
 }
 
 export function handlerAddPkg ( { uri } : UriInput) {
-    engine.addPkg(uri)
+  engine.addPkg(uri)
 }
 
 export function handleRemPkg ({ uri }: UriInput) {
-    engine.remPkg(uri)
-  }
+  engine.remPkg(uri)
+}
 
 export function handleExit () {
   engine.stop()
@@ -103,7 +103,7 @@ export function handleChangeContent (params: any) {
 }
 
 function addUriToCompiler (document: TextDocument, skipDelay?: boolean) {
-    const job: jobs.Job = {
+  const job: jobs.Job = {
     request: jobs.Request.apiAddUri,
     uri: document.uri, // Note: this typically has the file:// scheme (important for files as keys)
     src: document.getText()

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -74,8 +74,16 @@ export function handleAddUri ({ uri }: UriInput) {
 }
 
 export function handleRemUri ({ uri }: UriInput) {
-  engine.remUri(uri)
+    engine.remUri(uri)
 }
+
+export function handlerAddPkg ( { uri } : UriInput) {
+    engine.addPkg(uri)
+}
+
+export function handleRemPkg ({ uri }: UriInput) {
+    engine.remPkg(uri)
+  }
 
 export function handleExit () {
   engine.stop()
@@ -95,7 +103,7 @@ export function handleChangeContent (params: any) {
 }
 
 function addUriToCompiler (document: TextDocument, skipDelay?: boolean) {
-  const job: jobs.Job = {
+    const job: jobs.Job = {
     request: jobs.Request.apiAddUri,
     uri: document.uri, // Note: this typically has the file:// scheme (important for files as keys)
     src: document.getText()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -33,6 +33,12 @@ connection.onNotification(jobs.Request.apiAddUri, handlers.handleAddUri)
 // A file has been removed
 connection.onNotification(jobs.Request.apiRemUri, handlers.handleRemUri)
 
+// A fpkg has been added or updated
+connection.onNotification(jobs.Request.apiAddPkg, handlers.handlerAddPkg)
+
+// A fpkg has been removed
+connection.onNotification(jobs.Request.apiRemPkg, handlers.handleRemPkg)
+
 // cmd/*
 connection.onNotification(jobs.Request.cmdRunTests, handlers.handleRunTests)
 


### PR DESCRIPTION
fix #107 
tested with the latest version of flix, working smoothly.
Only includes `fpkg` files which are in a directory named `lib`.

- `*/lib/package.fpkg` is included
- `*/lib/subdirectory/package.fpkg` is included.
- - `*/package.fpkg` is not included.