### PR TITLE
add option for additional jvm parameters

### DIFF
--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -109,7 +109,11 @@ async function getFiles() {
  * @return void
 */
 async function passArgs(terminal:vscode.Terminal, flixFilename: string, args: string) {
-    let cmd = ['java', '-jar', flixFilename]
+    const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename])
     cmd.push(...await getFiles())
 
     if(args.trim().length != 0) {
@@ -153,7 +157,11 @@ export function runMain(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            let cmd = ['java', '-jar', flixFilename]
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename])
             cmd.push(...await getFiles())
             let terminal = getFlixTerminal()
             passCommandToTerminal(cmd, terminal)  
@@ -204,7 +212,11 @@ export function runMainNewTerminal(
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
             let terminal = newFlixTerminal()
-            let cmd = ['java', '-jar', flixFilename]
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename])
             cmd.push(...await getFiles())
             passCommandToTerminal(cmd, terminal)
         }
@@ -300,7 +312,11 @@ function getTerminal(name: string) {
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'init']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'init'])
             let terminal = getTerminal('init')
             passCommandToTerminal(cmd, terminal)
         }
@@ -322,7 +338,11 @@ export function cmdCheck(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'check']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'check'])
             let terminal = getTerminal('check')
             passCommandToTerminal(cmd, terminal)
         }
@@ -343,7 +363,11 @@ export function cmdBuild(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'build']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'build'])
             let terminal = getTerminal('build')
             passCommandToTerminal(cmd, terminal)
         }
@@ -364,7 +388,11 @@ export function cmdBuildJar(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'build-jar']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'build-jar'])
             let terminal = getTerminal('build-jar')
             passCommandToTerminal(cmd, terminal)
         }
@@ -385,7 +413,11 @@ export function cmdBuildPkg(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'build-pkg']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'build-pkg'])
             let terminal = getTerminal('build-pkg')
             passCommandToTerminal(cmd, terminal)
         }
@@ -406,7 +438,11 @@ export function cmdRunProject(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'run']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'run'])
             let terminal = getTerminal('run')
             passCommandToTerminal(cmd, terminal)
         }
@@ -427,7 +463,11 @@ export function cmdBenchmark(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'benchmark']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'benchmark'])
             let terminal = getTerminal('benchmark')
             passCommandToTerminal(cmd, terminal)
         }
@@ -448,7 +488,11 @@ export function cmdTests(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'test']
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'test'])
             let terminal = getTerminal('test')
             passCommandToTerminal(cmd, terminal)
         }
@@ -469,7 +513,12 @@ export function cmdTestWithFilter(
     ) {
         return async function handler () {
             const flixFilename = await getFlixFilename(context, launchOptions)
-            const cmd = ['java', '-jar', flixFilename, 'test']
+            // const jvm = extraArgumentsToTheJVM();
+            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+            const cmd = ['java']
+            if(jvm.length != 0)
+                cmd.push(...jvm.split(' '))
+            cmd.push(...['-jar', flixFilename, 'test'])
             const input = await vscode.window.showInputBox({
                 prompt: "Enter names of test functions separated by spaces",
                 placeHolder: "test01 test02 ...",

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -103,24 +103,25 @@ async function getFiles() {
 
 /**
  * sends a java command to compile and run flix program of vscode window to the terminal.
- *
- * @param terminal vscode.Terminal to receive the command. 
- *
- * @return void
-*/
-async function passArgs(terminal:vscode.Terminal, flixFilename: string, args: string) {
-    const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename])
-    cmd.push(...await getFiles())
-
-    if(args.trim().length != 0) {
-        cmd.push("--args")
-        cmd.push(args)
-    }
-    passCommandToTerminal(cmd, terminal)  
+ * 
+ * @param terminal vscode.Terminal
+ * @param args string
+ * @param context vscode.ExtensionContext
+ * @param launchOptions LaunchOptions
+ */
+async function passArgs (
+    terminal:vscode.Terminal,
+    args: string,
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        let cmd = await getJVMCmd(context, launchOptions)
+        cmd.push(...await getFiles())
+        if(args.trim().length != 0) {
+            cmd.push("--args")
+            cmd.push(args)
+        }
+        passCommandToTerminal(cmd, terminal)  
 }
 
 /**
@@ -136,6 +137,26 @@ async function getFlixFilename(context:vscode.ExtensionContext, launchOptions: L
     const globalStoragePath = context.globalStoragePath
     const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
     return await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
+}
+
+
+/**
+ * generate a java command to compile the flix program.
+ * @param context vscode.ExtensionContext
+ * @param launchOptions LaunchOptions
+ * @returns string[]
+ */
+ async function getJVMCmd(
+    context: vscode.ExtensionContext, 
+    launchOptions: LaunchOptions = defaultLaunchOptions
+    ) {
+        const flixFilename = await getFlixFilename(context, launchOptions)
+        const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
+        let cmd = ['java']
+        if(jvm.length != 0)
+        cmd.push(...jvm.split(' '))
+        cmd.push(...['-jar', flixFilename])
+        return cmd
 }
 
 
@@ -156,12 +177,7 @@ export function runMain(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename])
+            let cmd = await getJVMCmd(context, launchOptions)
             cmd.push(...await getFiles())
             let terminal = getFlixTerminal()
             passCommandToTerminal(cmd, terminal)  
@@ -184,12 +200,11 @@ export function runMainWithArgs(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
             let input = await takeInputFromUser()
             if(input != undefined)
             {
                 let terminal = getFlixTerminal()
-                await passArgs(terminal, flixFilename, input)
+                await passArgs(terminal, input, context, launchOptions)
             }
         }
 }
@@ -210,13 +225,8 @@ export function runMainNewTerminal(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
             let terminal = newFlixTerminal()
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename])
+            let cmd = await getJVMCmd(context, launchOptions)
             cmd.push(...await getFiles())
             passCommandToTerminal(cmd, terminal)
         }
@@ -239,12 +249,11 @@ export function runMainNewTerminalWithArgs(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
             let input = await takeInputFromUser()
             if(input != undefined)
             {
                 let terminal = newFlixTerminal()
-                await passArgs(terminal, flixFilename, input)
+                await passArgs(terminal, input, context, launchOptions)
             }
         }
 }
@@ -311,12 +320,8 @@ function getTerminal(name: string) {
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'init'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('init')
             let terminal = getTerminal('init')
             passCommandToTerminal(cmd, terminal)
         }
@@ -337,12 +342,8 @@ export function cmdCheck(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'check'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('check')
             let terminal = getTerminal('check')
             passCommandToTerminal(cmd, terminal)
         }
@@ -362,12 +363,8 @@ export function cmdBuild(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'build'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('build')
             let terminal = getTerminal('build')
             passCommandToTerminal(cmd, terminal)
         }
@@ -387,12 +384,8 @@ export function cmdBuildJar(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'build-jar'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('build-jar')
             let terminal = getTerminal('build-jar')
             passCommandToTerminal(cmd, terminal)
         }
@@ -412,12 +405,8 @@ export function cmdBuildPkg(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'build-pkg'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('build-pkg')
             let terminal = getTerminal('build-pkg')
             passCommandToTerminal(cmd, terminal)
         }
@@ -437,12 +426,8 @@ export function cmdRunProject(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'run'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('run')
             let terminal = getTerminal('run')
             passCommandToTerminal(cmd, terminal)
         }
@@ -462,12 +447,8 @@ export function cmdBenchmark(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'benchmark'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('benchmark')
             let terminal = getTerminal('benchmark')
             passCommandToTerminal(cmd, terminal)
         }
@@ -487,12 +468,8 @@ export function cmdTests(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'test'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('test')
             let terminal = getTerminal('test')
             passCommandToTerminal(cmd, terminal)
         }
@@ -512,13 +489,8 @@ export function cmdTestWithFilter(
     launchOptions: LaunchOptions = defaultLaunchOptions
     ) {
         return async function handler () {
-            const flixFilename = await getFlixFilename(context, launchOptions)
-            // const jvm = extraArgumentsToTheJVM();
-            const jvm:string = vscode.workspace.getConfiguration('flix').get('extraArgumentsToTheJVM')
-            const cmd = ['java']
-            if(jvm.length != 0)
-                cmd.push(...jvm.split(' '))
-            cmd.push(...['-jar', flixFilename, 'test'])
+            let cmd = await getJVMCmd(context, launchOptions)
+            cmd.push('test')
             const input = await vscode.window.showInputBox({
                 prompt: "Enter names of test functions separated by spaces",
                 placeHolder: "test01 test02 ...",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "flix.extraArgumentsToTheJVM": {
             "type": "string",
             "default": "",
-            "description": "jvm compiler options separated by specs"
+            "description": "Additional JVM arguments separated by spaces"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
           "type": "boolean",
           "default": true,
           "description": "Run the compiler on every change"
+        },
+        "flix.extraArgumentsToTheJVM": {
+            "type": "string",
+            "default": "",
+            "description": "jvm compiler options separated by specs"
         }
       }
     },

--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -37,7 +37,8 @@ export interface CompileOnChange {
 
 export interface UserConfiguration {
   compileOnSave: CompileOnSave,
-  compileOnChange: CompileOnChange
+  compileOnChange: CompileOnChange,
+  extraArgumentsToTheJVM: string
 }
 
 export interface StartEngineInput {


### PR DESCRIPTION
fix #108 
In the extension settings of vscode, a box in both `user` and `workspace` tabs is created which takes extra jvm arguments as input and passes these additional parameters to the run commands.
![input box](https://user-images.githubusercontent.com/45541010/124465257-d4db6f80-ddb2-11eb-8053-430aba79ab18.png)

Settings in `user` tab apply globally to any instance of VS Code you open.
Settings in `workspace` tab are stored inside your workspace and only apply when the workspace is opened. 


That means, if JVM arguments of the `workspace` tab are null, the VS Code will consider the JVM arguments given in `User` tab. 