### PR TITLE
Merge "Flix" and "Flix Compiler" Terminals

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -38,8 +38,6 @@ export const FPKG_GLOB_PATTERN = new vscode.RelativePattern(vscode.workspace.wor
 
 let outputChannel: vscode.OutputChannel
 
-let diagnosticsOutputChannel: vscode.OutputChannel
-
 // flag to keep track of whether errors were present last time we ran diagnostics
 let diagnosticsErrors = false
 
@@ -66,18 +64,18 @@ function getUserConfiguration () {
 function handlePrintDiagnostics ({ status, result }) {
   if (status === 'success') {
     if (diagnosticsErrors) {
-      diagnosticsOutputChannel.clear()
+      outputChannel.clear()
       diagnosticsErrors = false
     }
   } else {
-    diagnosticsOutputChannel.clear()
+    outputChannel.clear()
     diagnosticsErrors = true
     for (const res of result) {
       for (const diag of res.diagnostics) {
-        diagnosticsOutputChannel.appendLine(`${String.fromCodePoint(0x274C)} ${diag.fullMessage}`)
+        outputChannel.appendLine(`${String.fromCodePoint(0x274C)} ${diag.fullMessage}`)
       }
     }
-    diagnosticsOutputChannel.show(true)
+    outputChannel.show(true)
   }
 }
 
@@ -86,8 +84,7 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   initialiseState(context)
 
   // create output channels
-  diagnosticsOutputChannel = vscode.window.createOutputChannel('Flix Compiler')
-  outputChannel = diagnosticsOutputChannel
+  outputChannel = vscode.window.createOutputChannel('Flix Compiler')
 
   // create language client
   client = createLanguageClient({ context, outputChannel })
@@ -160,7 +157,6 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
 
   // clear outputs
   outputChannel.clear()
-  diagnosticsOutputChannel.clear()
   
   // show default output channel without changing focus
   outputChannel.show(true)
@@ -217,6 +213,5 @@ export function deactivate (): Thenable<void> | undefined {
   flixWatcher && flixWatcher.dispose()
   pkgWatcher && pkgWatcher.dispose()
   outputChannel && outputChannel.dispose()
-  diagnosticsOutputChannel && diagnosticsOutputChannel.dispose()
   return client ? client.stop() : undefined
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -75,7 +75,6 @@ function handlePrintDiagnostics ({ status, result }) {
         outputChannel.appendLine(`${String.fromCodePoint(0x274C)} ${diag.fullMessage}`)
       }
     }
-    outputChannel.show(true)
   }
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -86,8 +86,8 @@ export async function activate (context: vscode.ExtensionContext, launchOptions:
   initialiseState(context)
 
   // create output channels
-  outputChannel = vscode.window.createOutputChannel('Flix')
   diagnosticsOutputChannel = vscode.window.createOutputChannel('Flix Compiler')
+  outputChannel = diagnosticsOutputChannel
 
   // create language client
   client = createLanguageClient({ context, outputChannel })

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -85,6 +85,24 @@ async function takeInputFromUser() {
     return input
 }
 
+
+async function handleUnsavedFiles() {
+    let unsaved = []
+    const textDocuments = vscode.workspace.textDocuments
+    for(const textDocument of textDocuments)
+    {
+        if(textDocument.isDirty)
+            unsaved.push(textDocument)
+    }
+    if(unsaved.length != 0)
+    {
+        const items = ['run without saving', 'save all modified files']
+        const action = await vscode.window.showWarningMessage("Some of workspace files are not saved.", ...items)
+        if(action == 'save all modified files')
+            await vscode.workspace.saveAll(false)
+    }
+}
+
 /**
  * combines the paths of all flix files present in the current directory of vscode window.
  * 
@@ -93,6 +111,7 @@ async function takeInputFromUser() {
  * @return string of format "\<path_to_first_file\>" "\<path_to_second_file\>" ..........
 */
 async function getFiles() {
+    await handleUnsavedFiles()
     const flixFiles = await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)
     const fpkgFiles = await vscode.workspace.findFiles(FPKG_GLOB_PATTERN)
     let files = []
@@ -302,6 +321,7 @@ function getTerminal(name: string) {
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'init']
             let terminal = getTerminal('init')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -324,6 +344,7 @@ export function cmdCheck(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'check']
             let terminal = getTerminal('check')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -345,6 +366,7 @@ export function cmdBuild(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'build']
             let terminal = getTerminal('build')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -366,6 +388,7 @@ export function cmdBuildJar(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'build-jar']
             let terminal = getTerminal('build-jar')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -387,6 +410,7 @@ export function cmdBuildPkg(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'build-pkg']
             let terminal = getTerminal('build-pkg')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -408,6 +432,7 @@ export function cmdRunProject(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'run']
             let terminal = getTerminal('run')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -429,6 +454,7 @@ export function cmdBenchmark(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'benchmark']
             let terminal = getTerminal('benchmark')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -450,6 +476,7 @@ export function cmdTests(
             const flixFilename = await getFlixFilename(context, launchOptions)
             const cmd = ['java', '-jar', flixFilename, 'test']
             let terminal = getTerminal('test')
+            await handleUnsavedFiles()
             passCommandToTerminal(cmd, terminal)
         }
 }
@@ -479,6 +506,7 @@ export function cmdTestWithFilter(
             {
                 cmd.push(input)
                 let terminal = getTerminal('testWithFilter')
+                await handleUnsavedFiles()
                 passCommandToTerminal(cmd, terminal)
             }
         }


### PR DESCRIPTION
close #106 
close #121 

Now there's only one output channel `Flix Compiler`

The messages which were previously sent to "Flix" are now sent to "Flix Compiler" and the "Flix" channel is now removed.

![Screenshot from 2021-07-09 11-17-02](https://user-images.githubusercontent.com/45541010/125030440-c047f180-e0a8-11eb-81dd-d3a8cae84784.png)

If an error occurs in the code:
![Screenshot from 2021-07-09 11-17-36](https://user-images.githubusercontent.com/45541010/125030520-dd7cc000-e0a8-11eb-9204-7047fabce216.png)
