### PR TITLE
Add `lawless` and `unlawful` modifiers to syntax highlighting

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -132,7 +132,7 @@
                 },
                 {
                     "name": "storage.type.modifier.flix",
-                    "match": "\\b(inline|opaque|override|mut|sealed)\\b"
+                    "match": "\\b(inline|mut|lawless|opaque|override|sealed|unlawful)\\b"
                 }
             ]
         },


### PR DESCRIPTION
Also alphabetized the modifiers in that group