### PR TITLE
Highlight function calls, variables and more

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -24,16 +24,25 @@
             "include": "#literal_string"
         },
         {
+            "include": "#literal_int"
+        },
+        {
             "include": "#annotations"
         },
         {
             "include": "#comments"
+        },
+        {
+            "include": "#function_names"
+        },
+        {
+            "include": "#variables"
         }
     ],
     "repository": {
         "function_declarations": {
             "name": "meta.function.flix",
-            "begin": "(?:(\\bpub)\\s+)?(def\\b)\\s+([a-z_][_[:alnum:]]*)\\s*\\(",
+            "begin": "(?:(\\bpub)\\s+)?(def\\b)\\s+([a-z_][_![:alnum:]]*)\\s*[\\(\\[]",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.declaration.flix"
@@ -54,15 +63,7 @@
                     "include": "#comments"
                 },
                 {
-                    "match": "([a-z_][_[:alnum:]]*)\\s*(:)",
-                    "captures": {
-                        "1": {
-                            "name": "variable.parameter.flix"
-                        },
-                        "2": {
-                            "name": "meta.colon.flix"
-                        }
-                    }   
+                    "include": "#variables"
                 }
             ]
         },
@@ -101,12 +102,16 @@
                     "match": "\\b(case|match)\\b"
                 },
                 {
+                    "name": "keyword.control.try.flix",
+                    "match": "\\b(try|catch)\\b"
+                },
+                {
                     "name": "keyword.control.spawn.flix",
                     "match": "\\b(spawn)\\b"
                 },
                 {
-                    "name": "keyword.control.select.flix",
-                    "match": "\\b(select)\\b"
+                    "name": "keyword.control.chan.flix",
+                    "match": "\\b(chan)\\b"
                 },
                 {
                     "name": "keyword.operator.bool.flix",
@@ -125,8 +130,8 @@
                     "match": "\\b(default)\\b"
                 },
                 {
-                    "name": "keyword.expression.fixpoint.flix",
-                    "match": "\\b(from|into|project|solve|query|where)\\b"
+                    "name": "keyword.control.fixpoint.flix",
+                    "match": "\\b(from|into|project|solve|query|where|select)\\b"
                 },
                 {
                     "name": "keyword.expression.force.flix",
@@ -178,7 +183,7 @@
             "patterns": [
                 {
                     "name": "entity.name.type",
-                    "match": "\\b([A-Z_][_[:alnum:]]*)\\b"
+                    "match": "\\b(_?[A-Z][_[:alnum:]]*)\\b"
                 }
             ]
         },
@@ -201,25 +206,43 @@
                 {
                     "name": "constant.character.escape.flix",
                     "match": "\\\\."
+                },
+                {
+                    "begin": "\\$\\{",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.template-expression.begin.flix"
+                        }
+                    },
+                    "end": "\\}",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.template-expression.end.flix"
+                        }
+                    }
                 }
             ]
+        },
+        "literal_int": {
+            "name": "constant.numeric.decimal.flix",
+            "match": "[0-9]+"
         },
         "annotations": {
             "patterns": [
                 {
-                    "name": "annotation.benchmark.flix",
+                    "name": "storage.type.annotation.flix",
                     "match": "@benchmark"
                 },
                 {
-                    "name": "annotation.test.flix",
+                    "name": "storage.type.annotation.flix",
                     "match": "@test"
                 },
                 {
-                    "name": "annotation.test.flix",
+                    "name": "storage.type.annotation.flix",
                     "match": "@Space"
                 },
                 {
-                    "name": "annotation.test.flix",
+                    "name": "storage.type.annotation.flix",
                     "match": "@Time"
                 }
             ]
@@ -236,6 +259,30 @@
                     "end": "\\*/"
                 }
             ]
+        },
+        "function_names": {
+            "patterns": [
+                {
+                    "match": "\\b([a-z][_![:alnum:]]*)\\s*\\(",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.function.flix"
+                        }
+                    }
+                },
+                {
+                    "name": "entity.name.function.flix",
+                    "match": "(?<=\\|>\\s*)([a-z][_![:alnum:]]*)"
+                },
+                {
+                    "name": "entity.name.function.flix",
+                    "match": "(?<=\\b[A-Z][_[:alnum:]]*\\.\\s*)([a-z][_![:alnum:]]*)"
+                }
+            ]
+        },
+        "variables": {
+            "name": "variable.flix",
+            "match": "\\b([a-z_][_[:alnum:]]*)\\b"
         }
     }
 }

--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -110,10 +110,6 @@
                     "match": "\\b(spawn)\\b"
                 },
                 {
-                    "name": "keyword.control.chan.flix",
-                    "match": "\\b(chan)\\b"
-                },
-                {
                     "name": "keyword.operator.bool.flix",
                     "match": "\\b(not|and|or)\\b"
                 },
@@ -130,7 +126,7 @@
                     "match": "\\b(default)\\b"
                 },
                 {
-                    "name": "keyword.control.fixpoint.flix",
+                    "name": "keyword.expression.fixpoint.flix",
                     "match": "\\b(from|into|project|solve|query|where|select)\\b"
                 },
                 {

--- a/themes/FlixifyDark.json
+++ b/themes/FlixifyDark.json
@@ -1,91 +1,109 @@
 {
-	"name": "Flix Dark",
-	"type": "dark",
+    "name": "Flix Dark",
+    "type": "dark",
 
     "tokenColors": [
-		{
-			"scope": "comment",
-			"settings": {
-				"foreground": "#6A9955"
-			}
-		},
-		{
-			"scope": "constant.language",
-			"settings": {
-				"foreground": "#569cd6"
-			}
+        {
+            "scope": "comment",
+            "settings": {
+                "foreground": "#6A9955"
+            }
         },
         {
-			"scope": "constant.language.effect.flix",
-			"settings": {
-				"foreground": "#bf8c00"
-			}
-		},
-		{
-			"scope": "keyword",
-			"settings": {
-				"foreground": "#569cd6"
-			}
-        },
-		{
-			"scope": "keyword.control",
-			"settings": {
-				"foreground": "#C586C0"
-			}
-		},
-		{
-			"scope": "keyword.operator",
-			"settings": {
-				"foreground": "#8a8a8a"
-			}
-        },
-		{
-			"scope": "keyword.expression.cast",
-			"settings": {
-				"foreground": "#B33A3A"
-			}
+            "scope": "constant.language",
+            "settings": {
+                "foreground": "#569cd6"
+            }
         },
         {
-			"scope": "keyword.expression.hole",
-			"settings": {
-				"foreground": "#c26242"
-			}
+            "scope": "constant.language.effect.flix",
+            "settings": {
+                "foreground": "#bf8c00"
+            }
         },
         {
-			"scope": "entity.name.type",
-			"settings": {
-				"foreground": "#4EC9B0"
-			}
+            "scope": "keyword",
+            "settings": {
+                "foreground": "#569cd6"
+            }
         },
         {
-			"scope": "storage.type.modifier",
-			"settings": {
-				"foreground": "#569cd6"
-			}
+            "scope": "keyword.control",
+            "settings": {
+                "foreground": "#C586C0"
+            }
         },
         {
-			"scope": "annotation",
-			"settings": {
-				"foreground": "#8fffdd"
-			}
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#8a8a8a"
+            }
         },
         {
-			"scope": "string",
-			"settings": {
-				"foreground": "#ce9178"
-			}
-		},
+            "scope": "keyword.expression.cast",
+            "settings": {
+                "foreground": "#B33A3A"
+            }
+        },
         {
-			"scope": "entity.name.function",
-			"settings": {
-				"foreground": "#DCDCAA"
-			}
-		},
+            "scope": "keyword.expression.hole",
+            "settings": {
+                "foreground": "#c26242"
+            }
+        },
         {
-			"scope": "variable.parameter",
-			"settings": {
-				"foreground": "#9CDCFE"
-			}
-		}
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#4EC9B0"
+            }
+        },
+        {
+            "scope": "storage.type.modifier",
+            "settings": {
+                "foreground": "#569cd6"
+            }
+        },
+        {
+            "scope": "annotation",
+            "settings": {
+                "foreground": "#8fffdd"
+            }
+        },
+        {
+            "scope": "string",
+            "settings": {
+                "foreground": "#ce9178"
+            }
+        },
+        {
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#DCDCAA"
+            }
+        },
+        {
+            "scope": "variable",
+            "settings": {
+                "foreground": "#9CDCFE"
+            }
+        },
+        {
+            "scope": "punctuation.definition.template-expression.begin",
+            "settings": {
+                "foreground": "#569CD6"
+            }
+        },
+        {
+            "scope": "punctuation.definition.template-expression.end",
+            "settings": {
+                "foreground": "#569CD6"
+            }
+        },
+        {
+            "scope": "constant.numeric",
+            "settings": {
+                "foreground": "#B5CEA8"
+            }
+        }
     ]
 }


### PR DESCRIPTION
The first image below shows what the highlighting looks like with this patch. (In particular, issue #133 is partially addressed. I think it's possible to address that issue fully by following [the approach taken in the builtin JavaScript extension](https://github.com/microsoft/vscode/blob/abff164c84d1075a9a09b7b36590183cd4f2e1c3/extensions/javascript/syntaxes/JavaScript.tmLanguage.json#L4701-L4721).)

The second image below shows that this patch fails to highlight simple function names that appear in multi-line pipes. I haven't yet figured out a way to match such names since VSCode only checks one line at a time unless one uses `begin` and `end` (which require the presence of some kind of delimiters).

By the way, the theme file mixed tabs and spaces, and I took the liberty of converting it to spaces only. Sorry for polluting the pull request with this.

![flix-highlight-more](https://user-images.githubusercontent.com/129259/131256536-bb296cb7-7eb7-4323-b9b9-310af2a3128e.png)

![flix-highlight-more-bug](https://user-images.githubusercontent.com/129259/131256638-3637c2c4-59ac-4f29-be93-c39334c2e00a.png)
