### PR TITLE
Add support for DocumentSymbol to display outline and breadcrumbs (#125)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Thomas Søe Plougsgaard](https://github.com/plougsgaard)
 - [Manoj Kumar](https://github.com/manoj2601)
 - [Jacob Harris Cryer Kragh](https://github.com/jhckragh)
+- [Nicola Dardanis](https://github.com/nicdard)

--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -41,6 +41,7 @@ export enum Request {
   lspGoto = 'lsp/goto',
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
+  lspDocumentSymbols = 'lsp/documentSymbols',
 
   internalRestart = 'ext/restart', // Internal Extension Request
   internalDownloadLatest = 'ext/downloadLatest', // Internal Extension Request

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -41,6 +41,7 @@ export enum Request {
   lspGoto = 'lsp/goto',
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
+  lspDocumentSymbols = 'lsp/documentSymbols',
 
   internalRestart = 'ext/restart', // Internal Extension Request
   internalDownloadLatest = 'ext/downloadLatest', // Internal Extension Request

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -52,7 +52,8 @@ export function handleInitialize (_params: InitializeParams) {
       },
       renameProvider: {
         prepareProvider: true
-      }
+      },
+      documentSymbolProvider: true,
     }
   }
   return result
@@ -191,6 +192,11 @@ function makeRenameJob (params: any) {
     newName: params.newName || ''
   }
 }
+
+/**
+ * @function 
+ */
+export const handleDocumentSymbols = makePositionalHandler(jobs.Request.lspDocumentSymbols);
 
 /**
  * @function

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -72,6 +72,9 @@ connection.onPrepareRename(handlers.handlePrepareRename)
 
 connection.onRenameRequest(handlers.handleRename)
 
+// Find DocumentSymbols hierarchical information to dispaly outline and breadcrumb
+connection.onDocumentSymbol(handlers.handleDocumentSymbols)
+
 // Make the text document manager listen on the connection
 // for open, change and close text document events
 documents.listen(connection)


### PR DESCRIPTION
Fix: #125

Add `lsp/documentSymbols` handler.
The request has been implemented in the language server here: https://github.com/flix/flix/pull/2289
It is still under development, as for now it returns just an hardcoded list of `DocumentSymbols`.