### PR TITLE
Add support for SymbolInformation and lsp/workspaceSymbols request.

### DIFF
--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -42,6 +42,7 @@ export enum Request {
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
   lspDocumentSymbols = 'lsp/documentSymbols',
+  lspWorkspaceSymbols = 'lsp/workspaceSymbols',
 
   internalRestart = 'ext/restart', // Internal Extension Request
   internalDownloadLatest = 'ext/downloadLatest', // Internal Extension Request

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -42,6 +42,7 @@ export enum Request {
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
   lspDocumentSymbols = 'lsp/documentSymbols',
+  lspWorkspaceSymbols = 'lsp/workspaceSymbols',
 
   internalRestart = 'ext/restart', // Internal Extension Request
   internalDownloadLatest = 'ext/downloadLatest', // Internal Extension Request

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -54,6 +54,7 @@ export function handleInitialize (_params: InitializeParams) {
         prepareProvider: true
       },
       documentSymbolProvider: true,
+      workspaceSymbolProvider: true,
     }
   }
   return result
@@ -197,6 +198,19 @@ function makeRenameJob (params: any) {
  * @function 
  */
 export const handleDocumentSymbols = makePositionalHandler(jobs.Request.lspDocumentSymbols);
+
+/**
+ * @function
+ */
+export const handleWorkspaceSymbols = enqueueUnlessHasErrors(makeWorkspaceSymbolsJob, makeDefaultResponseHandler, hasErrorsHandlerForCommands)
+
+function makeWorkspaceSymbolsJob(params: any) {
+    return {
+        request: jobs.Request.lspWorkspaceSymbols,
+        position: params.position,
+        query: params.query || ''
+    }
+}
 
 /**
  * @function

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -74,6 +74,8 @@ connection.onRenameRequest(handlers.handleRename)
 
 // Find DocumentSymbols hierarchical information to dispaly outline and breadcrumb
 connection.onDocumentSymbol(handlers.handleDocumentSymbols)
+// Find WorkspaceSymbols information.
+connection.onWorkspaceSymbol(handlers.handleWorkspaceSymbols)
 
 // Make the text document manager listen on the connection
 // for open, change and close text document events


### PR DESCRIPTION
Add support [`lsp/workspaceSymbols`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_symbol)

This allows to search through the whole workspace for symbols. To try it press `ctrl` + `T`.

It has been tested with the SymbolProvider implemented  in https://github.com/flix/flix/pull/2385