### PR TITLE
Add support for lsp/implementation request

### DIFF
--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -39,6 +39,7 @@ export enum Request {
   lspComplete = 'lsp/complete',
   lspHover = 'lsp/hover',
   lspGoto = 'lsp/goto',
+  lspImplementation = 'lsp/implementation',
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
   lspDocumentSymbols = 'lsp/documentSymbols',

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -39,6 +39,7 @@ export enum Request {
   lspComplete = 'lsp/complete',
   lspHover = 'lsp/hover',
   lspGoto = 'lsp/goto',
+  lspImplementation = 'lsp/implementation',
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
   lspDocumentSymbols = 'lsp/documentSymbols',

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -55,6 +55,7 @@ export function handleInitialize (_params: InitializeParams) {
       },
       documentSymbolProvider: true,
       workspaceSymbolProvider: true,
+      implementationProvider: true,
     }
   }
   return result
@@ -131,6 +132,11 @@ function makeGotoDefinitionResponseHandler (promiseResolver: Function) {
     promiseResolver()
   }
 }
+
+/**
+ * @function
+ */
+export const handleImplementation = makePositionalHandler(jobs.Request.lspImplementation);
 
 /**
  * @function

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -55,6 +55,9 @@ documents.onDidSave(handlers.handleSave)
 // Go to definition (from context menu or F12 usually)
 connection.onDefinition(handlers.handleGotoDefinition)
 
+// Go to implementation (Cntrl + F12)
+connection.onImplementation(handlers.handleImplementation)
+
 connection.onDocumentHighlight(handlers.handleHighlight)
 
 //Auto completion


### PR DESCRIPTION
Add support for `lsp/implementation` requests. This allows to [navigate](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-implementation) from a `class` to its `instances` by pressing `Cntrl + F12`.

See also: https://github.com/flix/flix/pull/2391