### PR TITLE
Extend syntax highlighting for number literals

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -21,6 +21,9 @@
             "include": "#literal_dec"
         },
         {
+            "include": "#literal_hex"
+        },
+        {
             "include": "#annotations"
         },
         {
@@ -178,6 +181,10 @@
         "literal_dec": {
             "name": "constant.numeric.decimal.flix",
             "match": "\\b[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*)?\\b"
+        },
+        "literal_hex": {
+            "name": "constant.numeric.hex.flix",
+            "match": "\\b0x[a-fA-F0-9](_*[a-fA-F0-9])*\\b"
         },
         "annotations": {
             "patterns": [

--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -18,7 +18,7 @@
             "include": "#literal_string"
         },
         {
-            "include": "#literal_int"
+            "include": "#literal_dec"
         },
         {
             "include": "#annotations"
@@ -175,9 +175,9 @@
                 }
             ]
         },
-        "literal_int": {
+        "literal_dec": {
             "name": "constant.numeric.decimal.flix",
-            "match": "\\b[0-9]+\\b"
+            "match": "\\b[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*)?\\b"
         },
         "annotations": {
             "patterns": [


### PR DESCRIPTION
Should address #160. 🙂 Here's a screenshot:

![flix-dec](https://user-images.githubusercontent.com/129259/140796801-e1957442-1f1c-4193-8938-4dcabf86f288.png)
