### PR TITLE
Highlight the contents of ${...} recursively

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -6,34 +6,41 @@
     "scopeName": "source.flix",
     "patterns": [
         {
-            "include": "#constants"
-        },
-        {
-            "include": "#keywords"
-        },
-        {
-            "include": "#literal_char"
-        },
-        {
-            "include": "#literal_string"
-        },
-        {
-            "include": "#literal_dec"
-        },
-        {
-            "include": "#literal_hex"
-        },
-        {
-            "include": "#annotations"
-        },
-        {
-            "include": "#types"
-        },
-        {
-            "include": "#comments"
+            "include": "#all_patterns"
         }
     ],
     "repository": {
+        "all_patterns": {
+            "patterns": [
+                {
+                    "include": "#constants"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#literal_char"
+                },
+                {
+                    "include": "#literal_string"
+                },
+                {
+                    "include": "#literal_dec"
+                },
+                {
+                    "include": "#literal_hex"
+                },
+                {
+                    "include": "#annotations"
+                },
+                {
+                    "include": "#types"
+                },
+                {
+                    "include": "#comments"
+                }
+            ]
+        },
         "constants": {
             "patterns": [
                 {
@@ -174,7 +181,13 @@
                         "0": {
                             "name": "punctuation.definition.template-expression.end.flix"
                         }
-                    }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#all_patterns"
+                        }
+                    ],
+                    "contentName": "meta.embedded.line.flix"
                 }
             ]
         },


### PR DESCRIPTION
As discussed in #133. The following screenshot shows the result with the current master version of Flix. 🙂

![flix-str-rec](https://user-images.githubusercontent.com/129259/141367399-eba8f3b9-71cb-4520-baaf-9a09d3c2c6ed.png)
