### PR TITLE
Highlight numbers with type suffix

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -192,12 +192,20 @@
             ]
         },
         "literal_dec": {
-            "name": "constant.numeric.decimal.flix",
-            "match": "\\b[0-9](_*[0-9])*(\\.[0-9](_*[0-9])*)?\\b"
+            "patterns": [
+                {
+                    "name": "constant.numeric.decimal.flix",
+                    "match": "\\b[0-9](_*[0-9])*\\.[0-9](_*[0-9])*(f32|f64)?\\b"
+                },
+                {
+                    "name": "constant.numeric.decimal.flix",
+                    "match": "\\b[0-9](_*[0-9])*(i8|i16|i32|i64|ii)?\\b"
+                }
+            ]
         },
         "literal_hex": {
             "name": "constant.numeric.hex.flix",
-            "match": "\\b0x[a-fA-F0-9](_*[a-fA-F0-9])*\\b"
+            "match": "\\b0x[a-fA-F0-9](_*[a-fA-F0-9])*(i8|i16|i32|i64|ii)?\\b"
         },
         "annotations": {
             "patterns": [


### PR DESCRIPTION
Should address #164. 🙂 Here's a screenshot showing the result:

![flix-num-suffix](https://user-images.githubusercontent.com/129259/141498939-e4669c5e-470e-498d-a3a5-33b37131b2af.png)
