### PR TITLE
Syntax highlight pub as modifier and opaque as decl keyword

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -89,7 +89,7 @@
                 },
                 {
                     "name": "keyword.declaration.flix",
-                    "match": "\\b(namespace|def|law|enum|case|type|rel|lat|alias|class|instance|with|pub)\\b"
+                    "match": "\\b(namespace|def|law|enum|case|type|rel|lat|alias|class|instance|with|opaque)\\b"
                 },
                 {
                     "name": "keyword.expression.cast.flix",
@@ -145,7 +145,7 @@
                 },
                 {
                     "name": "storage.type.modifier.flix",
-                    "match": "\\b(inline|mut|lawless|opaque|override|sealed|unlawful)\\b"
+                    "match": "\\b(inline|mut|lawless|pub|override|sealed|unlawful)\\b"
                 }
             ]
         },


### PR DESCRIPTION
As discussed in #168. 🙂

Screenshot (not my favorite theme, but it uses many different colors):

![kw](https://user-images.githubusercontent.com/129259/142053813-6d2bf3a1-8089-4db3-95e9-4e51f37a8532.png)
