### PR TITLE
Show changelog on compiler update

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -13,6 +13,7 @@ import initialiseState from './services/state'
 
 import * as handlers from './handlers'
 import { callResolversAndEmptyList } from './services/timers'
+import { registerFlixReleaseDocumentProvider } from './services/releaseVirtualDocument'
 
 const _ = require('lodash/fp')
 
@@ -84,6 +85,8 @@ function handlePrintDiagnostics ({ status, result }) {
 export async function activate (context: vscode.ExtensionContext, launchOptions: LaunchOptions = defaultLaunchOptions) {
   // activate state
   initialiseState(context)
+
+  registerFlixReleaseDocumentProvider(context);
 
   // create output channels
   outputChannel = vscode.window.createOutputChannel('Flix Compiler')

--- a/client/src/services/releaseVirtualDocument.ts
+++ b/client/src/services/releaseVirtualDocument.ts
@@ -38,7 +38,8 @@ const flixReleaseDocumentProvider = new (class implements vscode.TextDocumentCon
             `## Version: ${installedVersion.version.major}.${installedVersion.version.minor}.${installedVersion.version.patch}\n`
             + `${installedVersion.description}`;
       } else {
-        throw new Error(`The current installed compiler (${installedVersion.id}) doesn't match the requested one (${id}).`);
+        return 'Unable to get latest changelog. ' + 
+            'Please visit https://github.com/flix/flix/releases for more information on the available flix releases.';
       }
     }
   })();

--- a/client/src/services/releaseVirtualDocument.ts
+++ b/client/src/services/releaseVirtualDocument.ts
@@ -31,10 +31,11 @@ const scheme = 'flixcompiler';
 const flixReleaseDocumentProvider = new (class implements vscode.TextDocumentContentProvider {
   provideTextDocumentContent(uri: vscode.Uri): string {
       // use uri-path as text
-      const id = new Number(uri.path);
+      const id = new Number(uri.path.split('/')[0]);
       const installedVersion = getInstalledFlixVersion();
       if (id == installedVersion.id) {
-        return `Version: ${installedVersion.version.major}.${installedVersion.version.minor}.${installedVersion.version.patch}\n`
+        return `# New Flix Release!\n` + 
+            `## Version: ${installedVersion.version.major}.${installedVersion.version.minor}.${installedVersion.version.patch}\n`
             + `${installedVersion.description}`;
       } else {
         throw new Error(`The current installed compiler (${installedVersion.id}) doesn't match the requested one (${id}).`);
@@ -49,9 +50,7 @@ const flixReleaseDocumentProvider = new (class implements vscode.TextDocumentCon
  */
 async function openFlixReleaseDocument(uri: vscode.Uri) {
   // trigger the provider.
-  let document = await vscode.workspace.openTextDocument(uri);
-  await vscode.window.showTextDocument(document, { preview: false, preserveFocus: true });
-  await vscode.languages.setTextDocumentLanguage(document, "plaintext");
+  await vscode.commands.executeCommand("markdown.showPreview", uri);
 }
 
 /**
@@ -61,7 +60,7 @@ async function openFlixReleaseDocument(uri: vscode.Uri) {
 function createFlixReleaseContentUri({ id }: FlixRelease): vscode.Uri {
   const uri = vscode.Uri.from({
     scheme,
-    path: `${id}`,
+    path: `${id}/CHANGELOG`,
   });
   return uri;
 }

--- a/client/src/services/releaseVirtualDocument.ts
+++ b/client/src/services/releaseVirtualDocument.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Nicola Dardanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import { FlixRelease } from './releases';
+import { getInstalledFlixVersion } from './state';
+
+/**
+ * The scheme used to distinguish our documents.
+ */
+const scheme = 'flixcompiler';
+
+/**
+ * Handle documents where the uri scheme is [[scheme]] (flixcompiler):
+ *  - check whether the current installed version of the compiler is the same for which we want to display the release changelog.
+ *  - returns the body of the document to be displayed.
+ */
+const flixReleaseDocumentProvider = new (class implements vscode.TextDocumentContentProvider {
+  provideTextDocumentContent(uri: vscode.Uri): string {
+      // use uri-path as text
+      const id = new Number(uri.path);
+      const installedVersion = getInstalledFlixVersion();
+      if (id == installedVersion.id) {
+        return `Version: ${installedVersion.version.major}.${installedVersion.version.minor}.${installedVersion.version.patch}\n`
+            + `${installedVersion.description}`;
+      } else {
+        throw new Error(`The current installed compiler (${installedVersion.id}) doesn't match the requested one (${id}).`);
+      }
+    }
+  })();
+
+/**
+ * Open and show the document given by the provider when for the given [[uri]].
+ * Set the document language to plaintext.
+ * @param uri the path of is the id of the flix compiler.
+ */
+async function openFlixReleaseDocument(uri: vscode.Uri) {
+  // trigger the provider.
+  let document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document, { preview: false, preserveFocus: true });
+  await vscode.languages.setTextDocumentLanguage(document, "plaintext");
+}
+
+/**
+ * Builds a uri which is recognised by the flixReleaseDocumentProvider.
+ * @param id of the release we are willing to display
+ */
+function createFlixReleaseContentUri({ id }: FlixRelease): vscode.Uri {
+  const uri = vscode.Uri.from({
+    scheme,
+    path: `${id}`,
+  });
+  return uri;
+}
+
+/**
+ * Open the release changelog if [[flixRelease]] is the same release that was previously.
+ * @param flixRelease a release of the flix compiler.
+ */
+export async function openFlixReleaseOverview(flixRelease: FlixRelease) {
+  await openFlixReleaseDocument(createFlixReleaseContentUri(flixRelease));
+}
+
+/**
+ * Register the provider.  
+ */
+ export function registerFlixReleaseDocumentProvider({ subscriptions }: vscode.ExtensionContext) {
+    subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(scheme, flixReleaseDocumentProvider));
+}
+
+

--- a/client/src/services/releases.ts
+++ b/client/src/services/releases.ts
@@ -71,6 +71,7 @@ export async function fetchRelease (
     url: _.get(release, 'url'),
     id: _.get(release, 'id'),
     name: _.get(release, 'name'),
+    description: _.get(release, 'body'),
     version: tagToVersion(_.get(release, 'tag_name')),
     downloadUrl: _.get(release, 'assets.0.browser_download_url'),
     downloadedAt: Date.now()
@@ -105,6 +106,7 @@ export interface FlixRelease {
   url: string
   id: number
   name: string
+  description: string
   version: FlixVersion
   downloadUrl: string
   downloadedAt: number
@@ -114,6 +116,7 @@ export interface FlixRelease {
 interface GithubRelease {
     name: string
     id: number
+    body: string
     // eslint-disable-next-line camelcase
     published_at: string
     assets: Array<{

--- a/client/src/services/state.ts
+++ b/client/src/services/state.ts
@@ -15,6 +15,7 @@
  */
 import * as vscode from 'vscode'
 import { FlixRelease } from './releases'
+import { openFlixReleaseOverview } from './releaseVirtualDocument'
 
 let globalState: vscode.Memento
 
@@ -31,5 +32,6 @@ export function getInstalledFlixVersion (): FlixRelease {
 }
 
 export async function setInstalledFlixVersion (value) {
-  return globalState?.update(StateKeys.installedFlixVersion, value)
+  await globalState?.update(StateKeys.installedFlixVersion, value);
+  return openFlixReleaseOverview(value);
 }

--- a/client/src/util/ensureFlixExists.ts
+++ b/client/src/util/ensureFlixExists.ts
@@ -91,7 +91,7 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
       progressTitle: 'Downloading Flix Compiler',
       overwrite: true
     })
-    await setInstalledFlixVersion(flixRelease)
+    await setInstalledFlixVersion(flixRelease);
   })
 
   return filename

--- a/package.json
+++ b/package.json
@@ -92,16 +92,6 @@
         "title": "Flix Package Manager: test (with filter)"
       }
     ],
-    "resourceLabelFormatters": [
-      {
-        "scheme": "flixcompiler",
-        "formatting": {
-          "label": "Flix Release Notes",
-          "separator": "/",
-          "workspaceSuffix": "*"
-        }
-      }
-    ],
     "keybindings": [
       {
         "command": "flix.runMain",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,16 @@
         "title": "Flix Package Manager: test (with filter)"
       }
     ],
+    "resourceLabelFormatters": [
+      {
+        "scheme": "flixcompiler",
+        "formatting": {
+          "label": "Flix Release Notes",
+          "separator": "/",
+          "workspaceSuffix": "*"
+        }
+      }
+    ],
     "keybindings": [
       {
         "command": "flix.runMain",


### PR DESCRIPTION
Fix: #146

As for now, every time the compiler is updated, a new document (plaintext) is displayed in the editor containing the version of the compiler and the changelog as it is written in the release page. The changelog is displayed as a readonly document thanks to the [virtual document API](https://code.visualstudio.com/api/extension-guides/virtual-documents)

We could discuss whether this behavior is however disturbing for the user because it may interrupt an user reading some code while the extension is loading for example. However it is true that at this point the extension is still loading. To address the potential issue, we could substitute the current behavior with a notification having an open button which when clicked will open the document.

Note: This PR builds on top of https://github.com/flix/vscode-flix/pull/185
