### PR TITLE
feat: Add custom compiler path support

### DIFF
--- a/client/src/util/ensureFlixExists.ts
+++ b/client/src/util/ensureFlixExists.ts
@@ -29,14 +29,22 @@ async function downloadWithRetryDialog<T>(downloadFunc: () => Promise<T>): Promi
 
 export default async function ensureFlixExists ({ globalStoragePath, workspaceFolders, shouldUpdateFlix }) {
   if (!shouldUpdateFlix) {
-    // 1. If `flix.jar` exists in any workspace folder, use that
+
+    //1. If custom Path provided for `flix.jar`, use that
+    const customCompilerPath:string = vscode.workspace.getConfiguration('flix').get('customCompilerPath')
+    if(customCompilerPath.length != 0) {
+        if (fs.existsSync(customCompilerPath)) {
+            return customCompilerPath
+        }
+    }
+    // 2. If `flix.jar` exists in any workspace folder, use that
     for (const folder of workspaceFolders) {
       const filename = path.join(folder, FLIX_JAR)
       if (fs.existsSync(filename)) {
         return filename
       }
     }
-    // 2. If `flix.jar` exists in `globalStoragePath`, use that
+    // 3. If `flix.jar` exists in `globalStoragePath`, use that
     const filename = path.join(globalStoragePath, FLIX_JAR)
     if (fs.existsSync(filename)) {
       const installedFlixRelease: FlixRelease = getInstalledFlixVersion()
@@ -76,7 +84,7 @@ export default async function ensureFlixExists ({ globalStoragePath, workspaceFo
       return filename
     }
   }
-  // 3. Otherwise download `FLIX_URL` into `globalStoragePath` (create folder if necessary)
+  // 4. Otherwise download `FLIX_URL` into `globalStoragePath` (create folder if necessary)
   const filename = path.join(globalStoragePath, FLIX_JAR)
     
   if (!fs.existsSync(globalStoragePath)) {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
           "type": "string",
           "default": "",
           "description": "Additional Flix compiler options separated by spaces"
+        },
+        "flix.customCompilerPath": {
+            "type":"string",
+            "default":"",
+            "description": "Custom Flix Compiler path for `flix.jar`"
         }
       }
     },


### PR DESCRIPTION
Closes #210 
This PR adds a box in the extension settings where the user can specify the custom path for `flix.jar` compiler.

By default, the box is empty. In that case, the extension works as previously, i.e., it looks for the flix.jar file in the workspace folder or the global path. Else it uses the flix compiler from the path given by the user. If the path provided by the user does not exist, then it will work as previous.

![image](https://user-images.githubusercontent.com/45541010/194701390-b9da5feb-d6ff-487f-bede-edbbe378b64e.png)
