### PR TITLE
fix: Specify the classpath for the version check explicitly

### DIFF
--- a/server/src/util/javaVersion.ts
+++ b/server/src/util/javaVersion.ts
@@ -36,7 +36,7 @@ const getMajorVersion = _.flow(
 
 export default async function javaMajorVersion (rootPath: string): Promise<JavaVersion> {
   return new Promise((resolve) => {
-    ChildProcess.exec('java CheckJavaVersion', { cwd: path.join(rootPath, 'java') }, (error: any, stdout: any, stderror: any) => {
+    ChildProcess.exec('java -cp . CheckJavaVersion', { cwd: path.join(rootPath, 'java') }, (error: any, stdout: any, stderror: any) => {
       if (error) {
         return resolve(unknownJavaVersion)
       }


### PR DESCRIPTION
The current code relies on the JVM's default classpath (the current dir), which is used when the CLASSPATH environment variable is not set.

The CLASSPATH variable might be set globally or in my case set by another vscode plugin (e.g. nix-environment-selector) and then cause the invocation of `CheckJavaVersion` to fail with a hard-to-debug error even when jdk 11+ is installed: 
```Flix requires Java 11 or later. Found "unknown version".```

The added '-cp' command line parameter is available at least from jdk7 (https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html#CBBIAJDA)

There is some overlap with https://github.com/flix/vscode-flix/pull/93, but this has a conflict and seems abandoned.

I agree to release my contributions under Apache 2.