### PR TITLE
refactor: remove deprecated globalStoragePath, use globalStorageUri instead

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -173,7 +173,7 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
   // show default output channel without changing focus
   outputChannel.show(true)
 
-  const globalStoragePath = context.globalStoragePath
+  const globalStoragePath = context.globalStorageUri.fsPath;
   const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
   const workspaceFiles: [string] = _.map(vsCodeUriToUriString, (await vscode.workspace.findFiles(FLIX_GLOB_PATTERN)))
   const workspacePkgs: [string] = _.map(vsCodeUriToUriString, (await vscode.workspace.findFiles(FPKG_GLOB_PATTERN)))
@@ -191,7 +191,7 @@ async function startSession (context: vscode.ExtensionContext, launchOptions: La
     workspaceFolders,
     extensionPath: extensionObject.extensionPath || context.extensionPath,
     extensionVersion: extensionObject.packageJSON.version,
-    globalStoragePath: context.globalStoragePath,
+    globalStoragePath,
     workspaceFiles,
     workspacePkgs,
     workspaceJars,

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -182,7 +182,7 @@ async function passArgs (
  * @returns string (path of `flix.jar`)
  */
 async function getFlixFilename(context:vscode.ExtensionContext, launchOptions: LaunchOptions) {
-    const globalStoragePath = context.globalStoragePath
+    const globalStoragePath = context.globalStorageUri.fsPath;
     const workspaceFolders = _.map(_.flow(_.get('uri'), _.get('fsPath')), vscode.workspace.workspaceFolders)
     return await ensureFlixExists({ globalStoragePath, workspaceFolders, shouldUpdateFlix: launchOptions.shouldUpdateFlix })
 }


### PR DESCRIPTION
When running my tests this worked as expected, and the value of `context.globalStorageUri.fsPath` was the excact same as the value of `context.globalStoragePath`. This PR is a duplicate of https://github.com/flix/vscode-flix/pull/207, hence this change should close both.