### PR TITLE
feat: Added option to toggle `--explain` flag

### DIFF
--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -38,6 +38,9 @@ export async function createSharedRepl(context: vscode.ExtensionContext, launchO
     }
     let cmd = await getJVMCmd(context, launchOptions)
     cmd.push('repl')
+    if(vscode.workspace.getConfiguration('flix').get('explain.enabled')) {
+        cmd.push("--explain")
+    }
     FLIX_TERMINAL.sendText(quote(cmd))
 }
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
           "default": true,
           "description": "Run the compiler on every change"
         },
+        "flix.explain.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include suggestions on how to solve errors"
+        },
         "flix.extraJvmArgs": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "flix.explain.enabled": {
             "type": "boolean",
             "default": false,
-            "description": "Include suggestions on how to solve errors"
+            "description": "Enable detailed compiler error messages"
         },
         "flix.extraJvmArgs": {
           "type": "string",

--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -34,9 +34,14 @@ export interface CompileOnChange {
   delay: number
 }
 
+export interface Explain {
+    enabled: boolean;
+}
+
 export interface UserConfiguration {
   compileOnSave: CompileOnSave,
   compileOnChange: CompileOnChange,
+  explain: Explain,
   extraJvmArgs: string,
   extraFlixArgs: string
 }
@@ -116,6 +121,9 @@ export async function start (input: StartEngineInput) {
   args.push(...parseArgs(startEngineInput.userConfiguration.extraJvmArgs))
   args.push("-jar", flixFilename, "lsp", `${port}`)
   args.push(...parseArgs(startEngineInput.userConfiguration.extraFlixArgs))
+  if (startEngineInput?.userConfiguration.explain.enabled ?? false) {
+    args.push("--explain")
+  }
 
   const instance = flixInstance = spawn('java', args);
   const webSocketUrl = `ws://localhost:${port}`


### PR DESCRIPTION
Eventually this solves https://github.com/flix/vscode-flix/issues/152

This solution works for the compiler used to run the flix programs, but the compiler which compiles on-changes and on-saves seems to use the `--explain` flag as default, and I haven’t been able to find out where this is set.  

This means that this solution works when a program is run and for instance when the :check command is executed, but it’s currently not possible to not get the compiler for on-change and on-safe to not use the `--explain` flag.

Example of the compile on-change without explicitly setting the `--explain` flag:
![image](https://user-images.githubusercontent.com/101742082/214791160-c0ce89cb-bd5d-42b3-ae19-88155aae5053.png)
