### PR TITLE
fix: reconnect instead of restart when connection is lost due to standby

### DIFF
--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -61,7 +61,6 @@ export interface StartEngineInput {
 let flixInstance: ChildProcess | undefined = undefined;
 let startEngineInput: StartEngineInput
 let flixRunning: boolean = false
-let lastReconnect: number = 0;
 
 export function isRunning () {
   return flixRunning

--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -155,10 +155,6 @@ export async function start (input: StartEngineInput) {
         },
         onClose: function handleClose () {
           flixRunning = false
-          if (lastReconnect + 15000 < Date.now()) {
-            lastReconnect = Date.now();
-            reconnect(input, instance);
-          }
         }
       })
 
@@ -169,78 +165,6 @@ export async function start (input: StartEngineInput) {
 
   instance.stdout.addListener('data', connectToSocket)
 }
-
-export function ManualStopped() {
-    lastReconnect = Date.now();
-}
-
-export async function reconnect (input: StartEngineInput, flixInstance: ChildProcess | undefined) {
-    if (flixInstance || socket.isOpen()) {
-      await stop()
-    }
-
-    // copy input to local var for later use
-    startEngineInput = _.clone(input)
-  
-    const { flixFilename, extensionPath, workspaceFiles, workspacePkgs, workspaceJars } = input
-  
-    // get a port starting from 8888
-    const port = await getPortPromise({ port: 8888 })
-  
-    // build the Java args from the user configuration
-    // TODO split respecting ""
-    const args = []
-    args.push(...parseArgs(startEngineInput.userConfiguration.extraJvmArgs))
-    args.push("-jar", flixFilename, "lsp", `${port}`)
-    args.push(...parseArgs(startEngineInput.userConfiguration.extraFlixArgs))
-    if (startEngineInput?.userConfiguration.explain.enabled ?? false) {
-      args.push("--explain")
-    }
-  
-    const instance = flixInstance;
-    const webSocketUrl = `ws://localhost:${port}`
-  
-    // forward flix to own stdout & stderr
-    instance!.stdout?.pipe(process.stdout)
-    instance!.stderr?.pipe(process.stderr)
-  
-    const connectToSocket = (data: any) => {
-      console.log("connecting")
-      const str = data.toString().split(/(\r?\n)/g).join('')
-      if (str.includes(`:${port}`)) {
-        // initialise websocket, listening to messages and what not
-        socket.initialiseSocket({
-          uri: webSocketUrl,
-          onOpen: function handleOpen () {
-            flixRunning = true
-            const addUriJobs = _.map(workspaceFiles, uri => ({ uri, request: jobs.Request.apiAddUri }));
-            const addPkgJobs = _.map(workspacePkgs, uri => ({ uri, request: jobs.Request.apiAddPkg }));
-            const addJarJobs = _.map(workspaceJars, uri => ({ uri, request: jobs.Request.apiAddJar }));
-            const Jobs: jobs.Job[] = [
-              ...addUriJobs,
-              ...addPkgJobs,
-              ...addJarJobs,
-            ];
-            queue.initialiseQueues(Jobs)
-            handleVersion()
-            sendNotification(jobs.Request.internalFinishedJob)
-          },
-          onClose: function handleClose () {
-            console.log("closed")
-            flixRunning = false
-            if (lastReconnect + 15000 > Date.now()) {
-                reconnect(input, instance);
-            }
-          }
-        })
-  
-        // now that the connection is established, there's no reason to listen for new messages
-        instance!.stdout?.removeListener('data', connectToSocket)
-      }
-    }
-  
-    instance!.stdout?.addListener('data', connectToSocket)
-  }
 
 /**
  * Parses the argument string into a list of arguments.

--- a/server/src/engine/socket.ts
+++ b/server/src/engine/socket.ts
@@ -91,7 +91,8 @@ export function initialiseSocket ({ uri, onOpen, onClose }: InitialiseSocketInpu
   
   webSocket.on('close', () => {
     if (lastManualStopTimestamp + 15000 < Date.now()) {
-        console.log("Connect to the flix server was lost, reconnecting...")
+        // This happends when the connections breaks unintentionally
+        console.log("Connection to the flix server was lost, reconnecting...")
         initialiseSocket({uri, onOpen, onClose})
         return
     } 
@@ -122,7 +123,7 @@ export async function closeSocket () {
   let retries = 0
   if (webSocket) {
     clearAllTimers()
-    lastManualStopTimestamp = Date.now();
+    lastManualStopTimestamp = Date.now()
     webSocket.close()
 
     while (retries++ < 50) {

--- a/server/src/engine/socket.ts
+++ b/server/src/engine/socket.ts
@@ -90,6 +90,7 @@ export function initialiseSocket ({ uri, onOpen, onClose }: InitialiseSocketInpu
   })
   
   webSocket.on('close', () => {
+    webSocketOpen = false
     if (lastManualStopTimestamp + 15000 < Date.now()) {
         // This happends when the connections breaks unintentionally
         console.log("Connection to the flix server was lost, trying to reconnect...")
@@ -101,7 +102,6 @@ export function initialiseSocket ({ uri, onOpen, onClose }: InitialiseSocketInpu
         })
         return
     } 
-    webSocketOpen = false
     onClose && setTimeout(onClose!, 0)
   })
 


### PR DESCRIPTION
This explores the option to simply reconnect to the socket once the connection is lost due to standby instead of restarting the entire flix compiler, which takes longer.

I will have to run a couple more tests later today to make sure this works, but initially it seems to work. 