### PR TITLE
fix: restart compiler when the java process dies

### DIFF
--- a/server/src/engine/socket.ts
+++ b/server/src/engine/socket.ts
@@ -19,6 +19,7 @@ import * as queue from './queue'
 import { sendNotification } from '../server'
 import { EventEmitter } from 'events'
 import { lspCheckResponseHandler } from '../handlers'
+import { getPort } from 'portfinder';
 
 const _ = require('lodash/fp')
 const WebSocket = require('ws')
@@ -114,6 +115,14 @@ export function initialiseSocket ({ uri, onOpen, onClose }: InitialiseSocketInpu
 }
 
 async function tryToConnect({ uri, onOpen, onClose }: InitialiseSocketInput, times: number) {
+    const uriPort = _.toInteger(uri.slice(-4));
+    getPort({port: uriPort},(err, freePort)=> {
+        if (uriPort == freePort) {
+            // This happens if the previously used port is now free
+            sendNotification(jobs.Request.internalRestart)
+            return
+        }
+    })
     let retries = times;
     while(retries-- > 0) {
         initialiseSocket({uri, onOpen, onClose})


### PR DESCRIPTION
This is related to the issue (https://github.com/flix/vscode-flix/pull/245#issuecomment-1410758239) where, if the java process died, we would log an error but not restart the flix compiler.

This solution restarts the compiler if the socket connection is closed and the client listener is no longer active. It does not remove the logged error.

> (I guess we have to be careful with multiple instances of VSCode running multiple instances of the Flix compiler.) https://github.com/flix/vscode-flix/pull/245#issuecomment-1410745090

I tested this and it still seems to work. I had two VSCode running multiple instances of the Flix compiler and then i killed one of the java processes, and only that instance began to restart its flix compiler.