### PR TITLE
fix: changed the error message for when we don't find a major java version

### DIFF
--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -107,14 +107,14 @@ export async function start (input: StartEngineInput) {
 
   // Check for valid Java version
   const { majorVersion, versionString } = await javaVersion(extensionPath)
-  if (majorVersion == 0) {
+  if (versionString === undefined) {
     // This happends when we are not able to run a java statement or get a java version
     sendNotification(jobs.Request.internalError, 
         "Unable to find java on PATH. Please check that Java is correctly installed and on your PATH")
     return
   }
   
-  if (majorVersion < 11) {
+  if (majorVersion! < 11) {
     sendNotification(jobs.Request.internalError, `Flix requires Java 11 or later. Found "${versionString}".`)
     return
   }

--- a/server/src/engine/flix.ts
+++ b/server/src/engine/flix.ts
@@ -107,6 +107,13 @@ export async function start (input: StartEngineInput) {
 
   // Check for valid Java version
   const { majorVersion, versionString } = await javaVersion(extensionPath)
+  if (majorVersion == 0) {
+    // This happends when we are not able to run a java statement or get a java version
+    sendNotification(jobs.Request.internalError, 
+        "Unable to find java on PATH. Please check that Java is correctly installed and on your PATH")
+    return
+  }
+  
   if (majorVersion < 11) {
     sendNotification(jobs.Request.internalError, `Flix requires Java 11 or later. Found "${versionString}".`)
     return

--- a/server/src/util/javaVersion.ts
+++ b/server/src/util/javaVersion.ts
@@ -20,12 +20,12 @@ const _ = require('lodash/fp')
 
 interface JavaVersion {
   majorVersion: number
-  versionString: string
+  versionString: string | undefined
 }
 
 const unknownJavaVersion: JavaVersion = {
   majorVersion: 0,
-  versionString: 'unknown version'
+  versionString: undefined
 }
 
 const getMajorVersion = _.flow(

--- a/server/src/util/javaVersion.ts
+++ b/server/src/util/javaVersion.ts
@@ -19,12 +19,12 @@ const ChildProcess = require('child_process')
 const _ = require('lodash/fp')
 
 interface JavaVersion {
-  majorVersion: number
+  majorVersion: number | undefined
   versionString: string | undefined
 }
 
 const unknownJavaVersion: JavaVersion = {
-  majorVersion: 0,
+  majorVersion: undefined,
   versionString: undefined
 }
 


### PR DESCRIPTION
Solves https://github.com/flix/vscode-flix/issues/198

This solution does not actually check if some JDK is on PATH but it simply sends an error if we are not able to run a Java statement or find a major Java version. Maybe this could also be our solution to https://github.com/flix/vscode-flix/pull/248 if we somehow included JAVA_HOME in the error message?