### PR TITLE
feat: add code actions

### DIFF
--- a/client/src/engine/jobs.ts
+++ b/client/src/engine/jobs.ts
@@ -45,6 +45,7 @@ export enum Request {
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
   lspDocumentSymbols = 'lsp/documentSymbols',
+  lspCodeAction = 'lsp/codeAction',
   lspWorkspaceSymbols = 'lsp/workspaceSymbols',
 
   internalRestart = 'ext/restart', // Internal Extension Request

--- a/client/src/services/codeActions.ts
+++ b/client/src/services/codeActions.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode'
+
+export default class codeActions implements vscode.CodeActionProvider {
+
+    public providedCodeActionKinds = []; // Types of code actions: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
+    public newText: string;
+
+    // Constructor changes depending on which properties we need for our code actions
+    constructor(kind: string, text: string) {
+        this.providedCodeActionKinds.push(kind);
+        this.newText = text;
+    }
+
+    // Should return a list of all the different code actions
+    public provideCodeActions(document: vscode.TextDocument, range: vscode.Range): vscode.CodeAction[] {
+		const insertTextCodeAction = this.exampleCodeAction(document, range);
+		return [
+			insertTextCodeAction 
+		];
+	}
+
+    // code action example (Inserts the result.edit.newText returned from the server request in the code):
+	private exampleCodeAction(document: vscode.TextDocument, range: vscode.Range): vscode.CodeAction {
+		const fix = new vscode.CodeAction("Label used for the light bulb menu", this.providedCodeActionKinds[0]);
+		fix.edit = new vscode.WorkspaceEdit();
+		fix.edit.insert(document.uri, range.start, this.newText);
+		return fix;
+	}
+}

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -46,6 +46,7 @@ export enum Request {
   lspUses = 'lsp/uses',
   lspRename = 'lsp/rename',
   lspDocumentSymbols = 'lsp/documentSymbols',
+  lspCodeAction = 'lsp/codeAction',
   lspWorkspaceSymbols = 'lsp/workspaceSymbols',
   lspSemanticTokens = 'lsp/semanticTokens',
 

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -55,6 +55,7 @@ export function handleInitialize (_params: InitializeParams) {
         prepareProvider: false
       },
       documentSymbolProvider: true,
+      codeActionProvider: true,
       workspaceSymbolProvider: true,
       implementationProvider: true,
       semanticTokensProvider: {
@@ -213,6 +214,11 @@ function makeRenameJob (params: any) {
  * @function 
  */
 export const handleDocumentSymbols = makePositionalHandler(jobs.Request.lspDocumentSymbols);
+
+/**
+ * @function 
+ */
+export const handleCodeAction = makePositionalHandler(jobs.Request.lspCodeAction);
 
 /**
  * @function

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -218,7 +218,14 @@ export const handleDocumentSymbols = makePositionalHandler(jobs.Request.lspDocum
 /**
  * @function 
  */
-export const handleCodeAction = makePositionalHandler(jobs.Request.lspCodeAction);
+export const handleCodeAction = makePositionalHandler(jobs.Request.lspCodeAction, hasErrorsHandlerForCommands, makeCodeActionResponseHandler);
+
+function makeCodeActionResponseHandler (promiseResolver: Function) {
+    return function responseHandler ({ status, result }: any) {
+      sendNotification(jobs.Request.lspCodeAction, { status, result })
+      promiseResolver()
+    }
+}
 
 /**
  * @function

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -84,6 +84,8 @@ connection.onDocumentSymbol(handlers.handleDocumentSymbols)
 // Find WorkspaceSymbols information.
 connection.onWorkspaceSymbol(handlers.handleWorkspaceSymbols)
 
+connection.onCodeAction(handlers.handleCodeAction)
+
 // Semantic tokens
 connection.languages.semanticTokens.on(handlers.handleSemanticTokens)
 


### PR DESCRIPTION
related to https://github.com/flix/vscode-flix/issues/233

This implements the vs-code side of code actions. When triggering the `onCodeAction` (by for instance hovering over a definition) this will currently result in the error
```
Unsupported request: 'JString(lsp/codeAction)'
```
This is due to [the compiler currently not supporting code actions](https://github.com/flix/flix/blob/master/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala#L177-L189). 
The other features of the compiler still seems to work, but I think we should wait with this merge until the compiler side supports code actions.