### PR TITLE
feat: report compiler crash

### DIFF
--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -316,6 +316,8 @@ export function lspCheckResponseHandler ({ status, result }: socket.FlixResponse
   clearDiagnostics()
   sendNotification(jobs.Request.internalDiagnostics, { status, result })
   if (status !== 'success') {
-    _.each(sendDiagnostics, result)
+    const didCrash = _.isEqual(result, {})
+    if (didCrash) sendNotification(jobs.Request.internalError, USER_MESSAGE.COMPILER_CRASHED())
+    else  _.each(sendDiagnostics, result)
   }
 }

--- a/server/src/util/userMessages.ts
+++ b/server/src/util/userMessages.ts
@@ -1,5 +1,9 @@
 export class USER_MESSAGE {
 
+    static COMPILER_CRASHED() { 
+        return 'The flix compiler crashed. See the crash report for details'
+    }
+
     static CONNECTION_ESTABLISHED(version:any, engine:any) { 
         const { major, minor, revision } = version
         return `Flix ${major}.${minor}.${revision} Ready! (Extension: ${engine.getExtensionVersion()}) (Using ${engine.getFlixFilename()})`


### PR DESCRIPTION
related to https://github.com/flix/vscode-flix/issues/202

This adds a popup (like the image below) when a crash occurs on the compiler side. 
My `_.isEqual(result, {})` check is a bit of a hack, and it kind of requires that we don't send empty diagnostic-results back unless it's from a crash.
If we want a better solution for this the language server would need to send either some more information back or we would need to send some special “crash” status back (which could lead to some other problems).


![image](https://user-images.githubusercontent.com/101742082/225094272-ac750e4e-b634-4d64-884a-3c6ddfabe39c.png)
