### PR TITLE
fix: pass 'extraFlixArgs' when creating shared REPL

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Jacob Harris Cryer Kragh](https://github.com/jhckragh)
 - [Nicola Dardanis](https://github.com/nicdard)
 - [Magnus Holm Rasmussen](https://github.com/mR4smussen)
+- [Holger Dal Mogensen](https://github.com/sockmaster27)

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -42,6 +42,7 @@ export async function createSharedRepl(context: vscode.ExtensionContext, launchO
     if(vscode.workspace.getConfiguration('flix').get('explain.enabled')) {
         cmd.push("--explain")
     }
+    cmd.push(...getExtraFlixArgs())
     FLIX_TERMINAL.sendText(quote(cmd))
 }
 


### PR DESCRIPTION
Fixes flix/flix#5522