### PR TITLE
feat: highlight `branch` and `jumpto` syntax

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -116,6 +116,10 @@
                     "match": "\\b(par)\\b"
                 },
                 {
+                    "name": "keyword.control.ast.flix",
+                    "match": "\\b(branch|jumpto)\\b"
+                },
+                {
                     "name": "keyword.operator.bool.flix",
                     "match": "\\b(not|and|or)\\b"
                 },
@@ -182,10 +186,6 @@
                 {
                     "name": "storage.type.modifier.flix",
                     "match": "\\b(lawful|pub|override|sealed|static)\\b"
-                },
-                {
-                  "name": "keyword.control.ast.flix",
-                  "match": "\\b(branch|jumpto)\\b"
                 }
             ]
         },

--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -182,6 +182,10 @@
                 {
                     "name": "storage.type.modifier.flix",
                     "match": "\\b(lawful|pub|override|sealed|static)\\b"
+                },
+                {
+                  "name": "keyword.control.ast.flix",
+                  "match": "\\b(branch|jumpto)\\b"
                 }
             ]
         },


### PR DESCRIPTION
This classifies the `branch` and `jumpto` as "keyword.control.ast.flix". 

This colors it red in the 'Flixify Dark' theme:
![image](https://github.com/flix/vscode-flix/assets/61235930/c7174dc1-d4ca-4e9b-82bf-92621b8a708d)

And purple in the default theme:
![image](https://github.com/flix/vscode-flix/assets/61235930/31c4fb46-1874-43a0-bc78-43400fb1dd38)

Fixes #272