### PR TITLE
fix: highlighting of identifiers in ASTs

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -235,7 +235,7 @@
                 },
                 {
                     "name": "constant.numeric.decimal.flix",
-                    "match": "\\b[0-9](_*[0-9])*(i8|i16|i32|i64|ii)?\\b"
+                    "match": "(?<!\\$)\\b[0-9](_*[0-9])*(i8|i16|i32|i64|ii)?\\b"
                 }
             ]
         },


### PR DESCRIPTION
Before:
![image](https://github.com/flix/vscode-flix/assets/61235930/52881c02-b634-4516-9889-7770b92e02ec)

After:
![image](https://github.com/flix/vscode-flix/assets/61235930/c1f0f83e-beef-433f-a8c2-c4239bbcf693)

Fixes #271