### PR TITLE
chore: remove `rel` and `lat` keywords

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -129,7 +129,7 @@
                 },
                 {
                     "name": "keyword.declaration.flix",
-                    "match": "\\b(eff|def|law|enum|case|type|rel|lat|alias|class|instance|with|without|opaque|mod)\\b"
+                    "match": "\\b(eff|def|law|enum|case|type|alias|class|instance|with|without|opaque|mod)\\b"
                 },
                 {
                     "name": "keyword.expression.cast.flix",


### PR DESCRIPTION
Fixes #308