### PR TITLE
chore: add `trait` keyword, drop `class` keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ based on the real Flix compiler infrastructure.
     - Find all references to a function.
     - Find all references to a local variable or formal parameter.
     - Find all references to an enum case.
-    - Find all implementations of a type class.
+    - Find all implementations of a trait.
 
 * __Symbols__
     - List all document symbols.

--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -129,7 +129,7 @@
         },
         {
           "name": "keyword.declaration.flix",
-          "match": "\\b(eff|def|law|enum|case|type|alias|class|instance|with|without|opaque|mod)\\b"
+          "match": "\\b(eff|def|law|enum|case|type|alias|trait|instance|with|without|opaque|mod)\\b"
         },
         {
           "name": "keyword.expression.cast.flix",


### PR DESCRIPTION

![image](https://github.com/flix/vscode-flix/assets/61235930/1831c323-6da1-4d3f-9adf-af204d17b93c)

![image](https://github.com/flix/vscode-flix/assets/61235930/50135d36-b113-4f1b-8171-03afe86ce95a)


Fixes #346