### PR TITLE
chore: drop `resume` keyword

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -104,10 +104,6 @@
           "match": "\\b(try|catch)\\b"
         },
         {
-          "name": "keyword.control.resume.flix",
-          "match": "\\b(resume)\\b"
-        },
-        {
           "name": "keyword.control.spawn.flix",
           "match": "\\b(spawn)\\b"
         },


### PR DESCRIPTION
 Fixes #352