### PR TITLE
chore: add built extension file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ client/server
 notes
 target
 flix.jar
+*.vsix


### PR DESCRIPTION
When running `npx @vscode/vsce package` a file named something like `flix-1.18.0.vsix` is output to the root directory.