### PR TITLE
chore: add `lib` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+lib
 out
 node_modules
 client/server


### PR DESCRIPTION
Ignore the generated `lib` folder in the test workspace.