### PR TITLE
ci: split `check` job into multiple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Run tests on VS Code ${{ matrix.vscode-version }}
@@ -69,6 +70,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Package extension
@@ -82,6 +84,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Check code formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  NODE_VERSION: '20.x'
+  JDK_VERSION: '21'
+
 jobs:
   configure:
     runs-on: ubuntu-latest
@@ -30,7 +34,7 @@ jobs:
         version=${version#^}
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  check:
+  test:
     runs-on: ubuntu-latest
     needs: configure
 
@@ -39,31 +43,48 @@ jobs:
         vscode-version:
         - ${{ needs.configure.outputs.minimum-version }}
         - stable
-        node-version:
-        - 18.x
-        - 20.x
-        jdk-version:
-        - '21'
 
     steps: 
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.jdk-version }}
-    - name: Use Node.js ${{ matrix.node-version }}
+        java-version: ${{ env.JDK_VERSION }}
+    - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: npm ci
-    - name: Check code formatting
-      run: npx prettier . --check
-    - name: Run linter
-      run: npx eslint .
     - name: Run tests on VS Code ${{ matrix.vscode-version }}
       run: xvfb-run -a npm test
       env: 
         VSCODE_VERSION: ${{ matrix.vscode-version }}
+  
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install dependencies
+      run: npm ci
     - name: Package extension
       run: npx --yes @vscode/vsce package
+  
+  check-style:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Check code formatting
+      run: npx --yes prettier . --check
+    - name: Run linter
+      run: npx --yes eslint .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ env.NODE_VERSION }}
     - name: Install dependencies
       run: npm ci
     - name: Run tests on VS Code ${{ matrix.vscode-version }}


### PR DESCRIPTION
Avoids running stuff like packaging and code style checking multiple times, when the outcome should not depend on the matrix.
This also makes it easier to target a specific job for local debugging.

NOTE: This removes testing with Node 18. This should not matter as Node is only used for the build process, and is not part of the tested product.