### PR TITLE
feat: highlight function- and struct arrow differently

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -173,10 +173,18 @@
         },
         {
           "name": "keyword.symbols.flix",
-          "match": "(\\->|~>|<\\-|=>)"
+          "match": "(~>|<\\-|=>)"
         },
         {
-          "name": "keyword.operator.semicolon.flix",
+          "name": "keyword.arrow.function.flix",
+          "match": "(\\s\\->\\s|\\s\\->|\\->\\s)"
+        },
+        {
+          "name": "keyword.operator.arrow.struct.flix",
+          "match": "\\->"
+        },
+        {
+          "name": "keyword.control.semicolon.flix",
           "match": ";"
         },
         {


### PR DESCRIPTION
Fixes #442