### PR TITLE
chore: drop `do` keyword

### DIFF
--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -68,10 +68,6 @@
           "match": "\\b(dbg)\\b"
         },
         {
-          "name": "keyword.control.do.flix",
-          "match": "\\b(do)\\b"
-        },
-        {
           "name": "keyword.control.applicativefor.flix",
           "match": "\\b(forA)\\b"
         },


### PR DESCRIPTION
Related to flix/flix#8926