### PR TITLE
fix: find reference tests relying on wrong expected behaviour

### DIFF
--- a/test/src/findReferences.test.ts
+++ b/test/src/findReferences.test.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 Holger Dal Mogensen
+ * Copyright 2024 Alexander Dybdahl Troelsen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/findReferences.test.ts
+++ b/test/src/findReferences.test.ts
@@ -43,13 +43,13 @@ suite('Find references', () => {
 
   test('Should find references to Shape.Circle enum case', async () => {
     await testFindReferences(mainDocUri, new vscode.Position(3, 9), [
-      new vscode.Location(mainDocUri, new vscode.Range(3, 9, 3, 22)),
+      new vscode.Location(mainDocUri, new vscode.Range(3, 9, 3, 15)),
       new vscode.Location(areaDocUri, new vscode.Range(5, 13, 5, 25)),
     ])
   })
   test('Should find references to Shape.Circle enum case-use', async () => {
     await testFindReferences(areaDocUri, new vscode.Position(5, 13), [
-      new vscode.Location(mainDocUri, new vscode.Range(3, 9, 3, 22)),
+      new vscode.Location(mainDocUri, new vscode.Range(3, 9, 3, 15)),
       new vscode.Location(areaDocUri, new vscode.Range(5, 13, 5, 25)),
     ])
   })

--- a/test/src/findReferences.test.ts
+++ b/test/src/findReferences.test.ts
@@ -80,6 +80,8 @@ suite('Find references', () => {
     await testFindReferences(equatableDocUri, new vscode.Position(2, 12), [
       new vscode.Location(equatableDocUri, new vscode.Range(2, 12, 2, 18)),
       new vscode.Location(equatableDocUri, new vscode.Range(9, 41, 9, 57)),
+      new vscode.Location(equatableDocUri, new vscode.Range(6, 12, 6, 18)),
+      new vscode.Location(equatableDocUri, new vscode.Range(15, 12, 15, 18)),
       new vscode.Location(equatableDocUri, new vscode.Range(22, 4, 22, 20)),
       new vscode.Location(equatableDocUri, new vscode.Range(29, 4, 29, 20)),
       new vscode.Location(equatableDocUri, new vscode.Range(36, 8, 36, 24)),

--- a/test/src/findReferences.test.ts
+++ b/test/src/findReferences.test.ts
@@ -176,15 +176,4 @@ suite('Find references', () => {
       new vscode.Location(equatableDocUri, new vscode.Range(22, 21, 22, 26)),
     ])
   })
-
-  test('Should find references to record label', async () => {
-    await testFindReferences(recordsDocUri, new vscode.Position(3, 6), [
-      new vscode.Location(recordsDocUri, new vscode.Range(2, 13, 2, 14)),
-      new vscode.Location(recordsDocUri, new vscode.Range(2, 48, 2, 49)),
-      new vscode.Location(recordsDocUri, new vscode.Range(3, 6, 3, 7)),
-      new vscode.Location(recordsDocUri, new vscode.Range(13, 14, 13, 15)),
-      new vscode.Location(recordsDocUri, new vscode.Range(15, 8, 15, 9)),
-      new vscode.Location(recordsDocUri, new vscode.Range(15, 15, 15, 16)),
-    ])
-  })
 })


### PR DESCRIPTION
This PR changes a few tests of the "find references", particularly in relation to the changes in behaviour due to the work happening at flix/flix#9449. Here, I will list the changes.

1. The tests regarding enum cases expected the references to contain `SourceLocation`s for the entire enum cases (including the parameters), where it ought to expect just the `SourceLocation` for the case symbols. This has been adjusted.
2. The tests for signatures never expected the implementations of them as references. I'd argue that, at least when finding the references to the signature from the declaration site, the result should include the implementing definitions. So the tests have been adjusted to expect this. Additionally, it could maybe be argued that finding the references to the signature from a call site should also return the particular implementation being invoked when this information can be known. However, currently this is hard to support.
3. The test regarding record labels has been removed. This is because we will not, at least at this time, support "find references" for record labels. This is because, since all labels of the same name are indistinguishable, the best we could hope for is returning a list of all labels with the given name either in the entire project or some limited part of it. Since it's very likely that a label name might be used in multiple unrelated contexts, it's not useful to return a list of all of these and worse yet, it might mislead a user to believe that there's a meaningful connection between all of these labels. At best, we could limit this by restricting the scope that we search for references in, but this doesn't really address the underlying issue. I argue, that it's better to just not support "find references" for record labels. Any reference to label that is likely to be relevant would be in the surrounding code anyways, such as within the same function or similar.

Related to flix/flix#9449.