### PR TITLE
refactor: add java flag to prevent warnings with jdk 24

### DIFF
--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -114,7 +114,7 @@ async function getJvmCmd(context: vscode.ExtensionContext, launchOptions: Launch
   const args: string[] = []
   args.push(...getExtraJvmArgs())
   const flixFilename = await getFlixFilename(context, launchOptions)
-  args.push(...['-jar', flixFilename])
+  args.push(...['--enable-native-access=ALL-UNNAMED', '-jar', flixFilename])
   return { cmd: 'java', args }
 }
 


### PR DESCRIPTION
- addresses #486 
- I added the flag and believe that the errors should go away and it doesn't affect lower jdk versions 

- output from the vscode extension debugging window

```
Found `flix.toml`. Checking dependencies...
Resolving Flix dependencies...
Downloading Flix dependencies...
Resolving Maven dependencies...
  Running Maven dependency resolver.
Downloading external jar dependencies...
Dependency resolution completed.
     __   _   _
    / _| | | (_)            Welcome to Flix 0.59.0
   | |_  | |  _  __  __
   |  _| | | | | \ \/ /     Enter an expression to have it evaluated.
   | |   | | | |  >  <      Type ':help' for more information.
   |_|   |_| |_| /_/\_\     Type ':quit' or press 'ctrl + d' to exit.
      
flix>
```