### PR TITLE
refactor: ShowAST creates ast file and gives notification of file path

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -63,9 +63,8 @@ function makeHandleRestartClient(context: vscode.ExtensionContext, launchOptions
 
 async function handleShowAst({ status, result }) {
   if (status === StatusCode.Success) {
-    const content: string = '// ' + result.title + '\n\n' + result.text
-    const document = await vscode.workspace.openTextDocument({ content: content, language: 'flix' })
-    vscode.window.showTextDocument(document)
+    const content: string = "AST saved to: "  + result.path
+    vscode.window.showInformationMessage(content)
   } else {
     const msg = USER_MESSAGE.CANT_SHOW_AST()
     vscode.window.showInformationMessage(msg)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -63,7 +63,7 @@ function makeHandleRestartClient(context: vscode.ExtensionContext, launchOptions
 
 async function handleShowAst({ status, result }) {
   if (status === StatusCode.Success) {
-    const content: string = "AST saved to: "  + result.path
+    const content: string = 'AST saved to: ' + result.path
     vscode.window.showInformationMessage(content)
   } else {
     const msg = USER_MESSAGE.CANT_SHOW_AST()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -63,7 +63,7 @@ function makeHandleRestartClient(context: vscode.ExtensionContext, launchOptions
 
 async function handleShowAst({ status, result }) {
   if (status === StatusCode.Success) {
-    const content: string = 'AST saved to: ' + result.path
+    const content: string = 'ASTs saved to: ' + result.path
     vscode.window.showInformationMessage(content)
   } else {
     const msg = USER_MESSAGE.CANT_SHOW_AST()

--- a/client/src/handlers/handlers.ts
+++ b/client/src/handlers/handlers.ts
@@ -356,18 +356,8 @@ export function cmdOutdated(context: vscode.ExtensionContext, launchOptions: Lau
  */
 export function showAst(client: LanguageClient) {
   return async function handler() {
-    const phaseInput = await vscode.window.showInputBox({
-      prompt: 'Enter the phase to show the AST for',
-      placeHolder: 'Phase',
-    })
-    const phase = phaseInput?.trim()
-    if (phase === undefined || phase.length === 0) {
-      return
-    }
-
     client.sendNotification(jobs.Request.lspShowAst, {
       uri: vscode.window.activeTextEditor.document.uri.fsPath,
-      phase: phase,
     })
   }
 }


### PR DESCRIPTION
Old implementation tried making a new file open.

Now it creates a notification of the path of pretty printed AST.

Addresses #485.