### PR TITLE
refactor: cyclic error diagnostic test

### DIFF
--- a/test/src/diagnostics.test.ts
+++ b/test/src/diagnostics.test.ts
@@ -59,7 +59,7 @@ suite('Diagnostics', () => {
   })
 
   test('Should show resolution error', async () => {
-    await testDiagnostics('ResolutionError.flix', "Cyclic type aliases:")
+    await testDiagnostics('ResolutionError.flix', 'Cyclic type aliases:')
   })
 
   test('Should show type error', async () => {


### PR DESCRIPTION
addresses #484, by ignoring the order of 'Even' and 'Odd' as long as the correct error is reported.