### PR TITLE
fix: dispose REPL terminals before replacing flix.jar on Windows

### DIFF
--- a/client/src/compiler/download.ts
+++ b/client/src/compiler/download.ts
@@ -33,7 +33,12 @@ async function downloadWithRetryDialog<T>(downloadFunc: () => Promise<T>): Promi
 
 /**
  * If a staged `flix.jar.new` exists from a previous download, move it into
- * place. This runs before the JVM starts, so the file is not locked.
+ * place.
+ *
+ * On Windows the unlink can fail with EBUSY / EPERM / EACCES when a JVM
+ * process (e.g. Flix REPL) still holds a lock on the file. The caller
+ * should dispose those terminals first, but if the lock persists we show
+ * a retry dialog so the user can close the process manually.
  */
 async function applyPendingUpdate(globalStoragePath: string): Promise<void> {
   const pendingFile = path.join(globalStoragePath, FLIX_JAR_NEW)
@@ -42,22 +47,31 @@ async function applyPendingUpdate(globalStoragePath: string): Promise<void> {
   }
 
   const targetFile = path.join(globalStoragePath, FLIX_JAR)
-  try {
-    // Node.js fs.rename on Windows does NOT atomically replace an existing
-    // file, so we must unlink first. Safe here because the JVM hasn't started.
-    await fs.promises.unlink(targetFile).catch(err => {
-      if (err.code !== 'ENOENT') {
-        throw err
+
+  while (true) {
+    try {
+      // Node.js fs.rename on Windows does NOT atomically replace an existing
+      // file, so we must unlink first.
+      await fs.promises.unlink(targetFile).catch(err => {
+        if (err.code !== 'ENOENT') {
+          throw err
+        }
+      })
+      await fs.promises.rename(pendingFile, targetFile)
+      // Show the changelog that was deferred from the download.
+      const installedVersion = getInstalledFlixVersion()
+      if (installedVersion) {
+        openFlixReleaseOverview(installedVersion)
       }
-    })
-    await fs.promises.rename(pendingFile, targetFile)
-    // Show the changelog that was deferred from the download.
-    const installedVersion = getInstalledFlixVersion()
-    if (installedVersion) {
-      openFlixReleaseOverview(installedVersion)
+      return
+    } catch (err) {
+      const { msg, option1, option2 } = USER_MESSAGE.ASK_APPLY_UPDATE_RETRY()
+      const selected = await vscode.window.showErrorMessage(msg, option1, option2)
+      if (selected === option1) {
+        continue
+      }
+      return
     }
-  } catch (err) {
-    console.warn('Failed to apply pending flix.jar update, will retry on next startup:', err)
   }
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -31,7 +31,7 @@ import {
   cmdDoc,
   cmdOutdated,
 } from './commands/replCommands'
-import { initSharedRepl, startRepl } from './repl/manager'
+import { initSharedRepl, startRepl, disposeAllRepls } from './repl/manager'
 import { LaunchOptions, defaultLaunchOptions } from './util/launchOptions'
 import { isProjectMode, getFlixGlobPattern } from './util/workspace'
 
@@ -70,6 +70,9 @@ function handleChangeEditor(editor: vscode.TextEditor | undefined) {
 function makeHandleRestartClient(context: vscode.ExtensionContext, launchOptions?: LaunchOptions) {
   return async function handleRestartClient() {
     callResolversAndEmptyList()
+    // Dispose all REPL terminals so their JVM processes release the lock on
+    // flix.jar — otherwise applyPendingUpdate cannot replace it on Windows.
+    disposeAllRepls()
     await startSession(context, launchOptions, client, outputChannel, flixLspTerminal, () => {
       initSharedRepl(context, launchOptions)
     })

--- a/client/src/repl/manager.ts
+++ b/client/src/repl/manager.ts
@@ -14,6 +14,20 @@ export function getFlixTerminal(): vscode.Terminal | null {
 }
 
 /**
+ * Disposes all Flix REPL terminals — including any orphaned ones from
+ * earlier sessions — so their JVM processes release file locks (e.g. on
+ * `flix.jar` on Windows).
+ */
+export function disposeAllRepls() {
+  flixTerminal = null
+  for (const terminal of vscode.window.terminals) {
+    if (terminal.name === 'Flix REPL') {
+      terminal.dispose()
+    }
+  }
+}
+
+/**
  * Creates and initializes persistent shared REPL on startup.
  */
 export async function initSharedRepl(context: vscode.ExtensionContext, launchOptions: LaunchOptions) {

--- a/client/src/ui/messages.ts
+++ b/client/src/ui/messages.ts
@@ -97,4 +97,12 @@ export class USER_MESSAGE {
       option1: 'Reload Now',
     }
   }
+
+  static ASK_APPLY_UPDATE_RETRY() {
+    return {
+      msg: 'Failed to update flix.jar — it may be locked by a running Flix process. Please close any Flix REPL terminals and retry.',
+      option1: 'Retry',
+      option2: 'Dismiss',
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- On Windows, `applyPendingUpdate` fails to replace `flix.jar` with the staged `flix.jar.new` because a running Flix REPL terminal's JVM holds a file lock on the jar.
- Adds `disposeAllRepls()` which closes **all** `"Flix REPL"` terminals (including orphans from earlier sessions) before a session restart, so the JVM releases the lock.
- If the file operation still fails (e.g. process hasn't fully exited yet), shows a retry dialog asking the user to close any remaining Flix processes instead of silently swallowing the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)