### PR TITLE
test: wait on lsp/check instead of fixed sleeps to reduce flakiness

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -15,7 +15,7 @@ import { USER_MESSAGE } from './ui/messages'
 
 import { setupProjectWatchers, setupSingleFileTracking, disposeWatchers } from './lsp/fileWatchers'
 import { startSession } from './lsp/session'
-import { getUserConfiguration } from './lsp/notifications'
+import { getUserConfiguration, getCheckCount } from './lsp/notifications'
 
 import { simulateDisconnect, showAst, allJobsFinished } from './commands/lspCommands'
 import {
@@ -135,6 +135,10 @@ export async function activate(context: vscode.ExtensionContext, launchOptions: 
   // Returns a promise resolving when all jobs are completely finished and the server is idle.
   // While most other commands can be awaited directly, this is useful for stuff like file creation, which indirectely triggers an asynchronous job.
   registerCommand('flix.allJobsFinished', allJobsFinished(client, eventEmitter))
+
+  // Returns the number of lsp/check responses observed since startup. Tests baseline this before a
+  // filesystem change and wait for it to advance, to deterministically detect the resulting check.
+  registerCommand('flix.checkCount', () => getCheckCount())
 
   if (isProjectMode()) {
     // In project mode, watch the file system for .flix/.fpkg/.jar/flix.toml changes.

--- a/client/src/lsp/notifications.ts
+++ b/client/src/lsp/notifications.ts
@@ -8,6 +8,22 @@ import { USER_MESSAGE } from '../ui/messages'
 
 let hasReceivedReadyMessage = false
 
+/**
+ * Number of `lsp/check` responses the client has observed since startup.
+ *
+ * Incremented once per check response, before the corresponding `internalFinishedAllJobs` signal.
+ * Used by the test suite to deterministically wait for the check triggered by a filesystem change,
+ * instead of sleeping a fixed duration.
+ */
+let checkCount = 0
+
+/**
+ * Returns the number of `lsp/check` responses observed since startup. See {@link checkCount}.
+ */
+export function getCheckCount() {
+  return checkCount
+}
+
 export function getUserConfiguration() {
   return vscode.workspace.getConfiguration('flix')
 }
@@ -68,6 +84,11 @@ export function setupNotificationListeners(
   )
 
   client.onNotification(jobs.Request.internalDiagnostics, ({ status, result }) => {
+    // Tick once per lsp/check response. The server sends this before `internalFinishedAllJobs`,
+    // so a test can baseline this count before a change and wait for it to advance.
+    checkCount++
+    eventEmitter.emit('checkCount', checkCount)
+
     if (getUserConfiguration().clearOutput.enabled) {
       flixLspTerminal.clear()
     }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
         "command": "flix.allJobsFinished",
         "title": "Flix (debugging): Wait for the compiler to finish processing",
         "enablement": "false"
+      },
+      {
+        "command": "flix.checkCount",
+        "title": "Flix (debugging): Get the number of lsp/check responses observed",
+        "enablement": "false"
       }
     ],
     "menus": {

--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -76,7 +76,8 @@ async function copyWorkspace(testWorkspaceName: string) {
     const urisToDelete = namesToDelete.map(name => vscode.Uri.joinPath(uri, name))
     await Promise.allSettled(urisToDelete.map(uri => vscode.workspace.fs.delete(uri)))
   }
-  await awaitCheck(() => clearDir(activeWorkspaceUri))
+  await clearDir(activeWorkspaceUri)
+  await processFileChange()
 
   const testWorkspacePath = path.resolve(__dirname, '../testWorkspaces', testWorkspaceName)
   await copyDirContents(vscode.Uri.file(testWorkspacePath), activeWorkspaceUri)
@@ -173,11 +174,32 @@ async function awaitIdle() {
 }
 
 /**
+ * Waits for the processing of a filesystem change to finish, using fixed sleeps to bracket the idle
+ * wait.
+ *
+ * Only used for the workspace setup in {@linkcode init}, which runs *before* the extension is
+ * active: there is no idle baseline to capture and the very first command triggers activation, so
+ * the check-count strategy used by {@linkcode awaitCheck} does not apply. In-test mutations (which
+ * run while the extension is active and idle) use {@linkcode awaitCheck} instead.
+ */
+async function processFileChange() {
+  // Wait for the file system watcher to pick up the change
+  await sleep(1000)
+
+  // Wait for the compiler to process the change
+  await awaitIdle()
+
+  // Wait for the diagnostics to be updated
+  await sleep(1000)
+}
+
+/**
  * Runs the filesystem `mutation`, then waits until the `lsp/check` it triggers has finished and the
  * compiler is idle.
  *
- * This is the synchronization primitive for all file-changing test helpers, and it is race-free
- * because it baselines the check count *before* the mutation:
+ * This is the synchronization primitive for in-test file mutations (those that run while the
+ * extension is already active and idle), and it is race-free because it baselines the check count
+ * *before* the mutation:
  *
  * - The leading {@linkcode waitForCheckSince} proves the file-system watcher fired and a check
  *   completed, so we never sample idle against stale, pre-change state (the old `sleep(1000)` was a
@@ -208,14 +230,13 @@ export async function addFile(uri: vscode.Uri, content: string | Uint8Array) {
  * Copies the contents of the given folder `from` to the folder `to`, leaving non-overlapping files intact.
  */
 export async function copyDirContents(from: vscode.Uri, to: vscode.Uri) {
-  await awaitCheck(async () => {
-    const contents = await vscode.workspace.fs.readDirectory(from)
-    const names = contents.map(([name, _]) => name)
+  const contents = await vscode.workspace.fs.readDirectory(from)
+  const names = contents.map(([name, _]) => name)
 
-    const uris = names.map(name => ({ from: vscode.Uri.joinPath(from, name), to: vscode.Uri.joinPath(to, name) }))
+  const uris = names.map(name => ({ from: vscode.Uri.joinPath(from, name), to: vscode.Uri.joinPath(to, name) }))
 
-    await Promise.allSettled(uris.map(({ from, to }) => vscode.workspace.fs.copy(from, to, { overwrite: true })))
-  })
+  await Promise.allSettled(uris.map(({ from, to }) => vscode.workspace.fs.copy(from, to, { overwrite: true })))
+  await processFileChange()
 }
 
 /**

--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -76,8 +76,7 @@ async function copyWorkspace(testWorkspaceName: string) {
     const urisToDelete = namesToDelete.map(name => vscode.Uri.joinPath(uri, name))
     await Promise.allSettled(urisToDelete.map(uri => vscode.workspace.fs.delete(uri)))
   }
-  await clearDir(activeWorkspaceUri)
-  await processFileChange()
+  await awaitCheck(() => clearDir(activeWorkspaceUri))
 
   const testWorkspacePath = path.resolve(__dirname, '../testWorkspaces', testWorkspaceName)
   await copyDirContents(vscode.Uri.file(testWorkspacePath), activeWorkspaceUri)
@@ -95,9 +94,10 @@ export async function open(docUri: vscode.Uri) {
  * Types the given `text` in the editor at the current position.
  */
 export async function typeText(text: string) {
-  await vscode.commands.executeCommand('type', { text })
-  await vscode.window.activeTextEditor.document.save()
-  await processFileChange()
+  await awaitCheck(async () => {
+    await vscode.commands.executeCommand('type', { text })
+    await vscode.window.activeTextEditor.document.save()
+  })
 }
 
 /**
@@ -106,12 +106,13 @@ export async function typeText(text: string) {
 export async function replaceDocumentContent(docUri: vscode.Uri, newContent: string) {
   const doc = await vscode.workspace.openTextDocument(docUri)
   await vscode.window.showTextDocument(doc)
-  const fullRange = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length))
-  const edit = new vscode.WorkspaceEdit()
-  edit.replace(docUri, fullRange, newContent)
-  await vscode.workspace.applyEdit(edit)
-  await doc.save()
-  await processFileChange()
+  await awaitCheck(async () => {
+    const fullRange = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length))
+    const edit = new vscode.WorkspaceEdit()
+    edit.replace(docUri, fullRange, newContent)
+    await vscode.workspace.applyEdit(edit)
+    await doc.save()
+  })
 }
 
 /**
@@ -130,46 +131,100 @@ export async function sleep(ms: number) {
 }
 
 /**
- * Waits for the processing of a newly added or deleted file to finish.
+ * Returns the number of `lsp/check` responses the extension has observed since startup.
+ *
+ * Backed by the `flix.checkCount` test command, which is incremented once per check response —
+ * before the corresponding idle signal.
  */
-async function processFileChange() {
-  // Wait for the file system watcher to pick up the change
-  await sleep(1000)
+async function getCheckCount(): Promise<number> {
+  return (await vscode.commands.executeCommand<number>('flix.checkCount')) ?? 0
+}
 
-  // Wait for the compiler to process the change
+/**
+ * The maximum time to wait for a filesystem change to trigger an `lsp/check` before falling back to
+ * {@linkcode awaitIdle}. Generous on purpose: every mutation in the suite triggers a check, so this
+ * should never be hit in practice — it only prevents a hang if a change unexpectedly produces no
+ * check (e.g. the compiler is still downloading on a cold CI run).
+ */
+const CHECK_TIMEOUT_MS = 20000
+
+/**
+ * Waits until the observed check count exceeds `since`, i.e. an `lsp/check` has completed.
+ *
+ * Resolves early (with a warning) after {@linkcode CHECK_TIMEOUT_MS} so a no-op change cannot hang
+ * the suite; the subsequent {@linkcode awaitIdle} still guarantees correctness in that case.
+ */
+async function waitForCheckSince(since: number) {
+  const deadline = Date.now() + CHECK_TIMEOUT_MS
+  while ((await getCheckCount()) <= since) {
+    if (Date.now() > deadline) {
+      console.warn(`waitForCheckSince: no lsp/check observed within ${CHECK_TIMEOUT_MS}ms (count still ${since})`)
+      return
+    }
+    await sleep(25)
+  }
+}
+
+/**
+ * Waits until the compiler is idle (all queued jobs finished).
+ */
+async function awaitIdle() {
   await vscode.commands.executeCommand('flix.allJobsFinished')
+}
 
-  // Wait for the diagnostics to be updated
-  await sleep(1000)
+/**
+ * Runs the filesystem `mutation`, then waits until the `lsp/check` it triggers has finished and the
+ * compiler is idle.
+ *
+ * This is the synchronization primitive for all file-changing test helpers, and it is race-free
+ * because it baselines the check count *before* the mutation:
+ *
+ * - The leading {@linkcode waitForCheckSince} proves the file-system watcher fired and a check
+ *   completed, so we never sample idle against stale, pre-change state (the old `sleep(1000)` was a
+ *   guess that the watcher had fired).
+ * - The trailing {@linkcode awaitIdle} proves the queue drained. At that point all
+ *   `publishDiagnostics` for this check have already been applied to VS Code's diagnostics
+ *   collection, because the server sends them before the idle signal on the same ordered channel
+ *   (so the old trailing `sleep(1000)` is unnecessary).
+ */
+async function awaitCheck<T>(mutation: () => Promise<T>): Promise<T> {
+  const before = await getCheckCount()
+  const result = await mutation()
+  await waitForCheckSince(before)
+  await awaitIdle()
+  return result
 }
 
 /**
  * Add a file with the given `uri` and `content`, and wait for the compiler to process this.
  */
 export async function addFile(uri: vscode.Uri, content: string | Uint8Array) {
-  await vscode.workspace.fs.writeFile(uri, Buffer.from(content))
-  await processFileChange()
+  await awaitCheck(async () => {
+    await vscode.workspace.fs.writeFile(uri, Buffer.from(content))
+  })
 }
 
 /**
  * Copies the contents of the given folder `from` to the folder `to`, leaving non-overlapping files intact.
  */
 export async function copyDirContents(from: vscode.Uri, to: vscode.Uri) {
-  const contents = await vscode.workspace.fs.readDirectory(from)
-  const names = contents.map(([name, _]) => name)
+  await awaitCheck(async () => {
+    const contents = await vscode.workspace.fs.readDirectory(from)
+    const names = contents.map(([name, _]) => name)
 
-  const uris = names.map(name => ({ from: vscode.Uri.joinPath(from, name), to: vscode.Uri.joinPath(to, name) }))
+    const uris = names.map(name => ({ from: vscode.Uri.joinPath(from, name), to: vscode.Uri.joinPath(to, name) }))
 
-  await Promise.allSettled(uris.map(({ from, to }) => vscode.workspace.fs.copy(from, to, { overwrite: true })))
-  await processFileChange()
+    await Promise.allSettled(uris.map(({ from, to }) => vscode.workspace.fs.copy(from, to, { overwrite: true })))
+  })
 }
 
 /**
  * Copy the file from `from` to `to`, and wait for the compiler to process this.
  */
 export async function copyFile(from: vscode.Uri, to: vscode.Uri) {
-  await vscode.workspace.fs.copy(from, to, { overwrite: true })
-  await processFileChange()
+  await awaitCheck(async () => {
+    await vscode.workspace.fs.copy(from, to, { overwrite: true })
+  })
 }
 
 /**
@@ -178,8 +233,9 @@ export async function copyFile(from: vscode.Uri, to: vscode.Uri) {
  * Throws if the file does not exist.
  */
 export async function deleteFile(uri: vscode.Uri) {
-  await vscode.workspace.fs.delete(uri)
-  await processFileChange()
+  await awaitCheck(async () => {
+    await vscode.workspace.fs.delete(uri)
+  })
 }
 
 /**

--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -18,6 +18,14 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 
 /**
+ * The maximum time to wait for a filesystem change to trigger an `lsp/check` before falling back to
+ * {@linkcode awaitIdle}. Generous on purpose: every mutation in the suite triggers a check, so this
+ * should never be hit in practice — it only prevents a hang if a change unexpectedly produces no
+ * check (e.g. the compiler is still downloading on a cold CI run).
+ */
+const CHECK_TIMEOUT_MS = 20000
+
+/**
  * Activates the extension and copies the contents of the given test workspace directory into the active workspace.
  *
  * @param testWorkspaceName The name of the workspace directory to copy, e.g. `codeActions`.
@@ -140,14 +148,6 @@ export async function sleep(ms: number) {
 async function getCheckCount(): Promise<number> {
   return (await vscode.commands.executeCommand<number>('flix.checkCount')) ?? 0
 }
-
-/**
- * The maximum time to wait for a filesystem change to trigger an `lsp/check` before falling back to
- * {@linkcode awaitIdle}. Generous on purpose: every mutation in the suite triggers a check, so this
- * should never be hit in practice — it only prevents a hang if a change unexpectedly produces no
- * check (e.g. the compiler is still downloading on a cold CI run).
- */
-const CHECK_TIMEOUT_MS = 20000
 
 /**
  * Waits until the observed check count exceeds `since`, i.e. an `lsp/check` has completed.


### PR DESCRIPTION
## Problem

The integration tests are flaky. The root cause is the synchronization in `test/src/util.ts`:

```ts
async function processFileChange() {
  await sleep(1000)                                            // hope the watcher fired
  await vscode.commands.executeCommand('flix.allJobsFinished') // wait for idle
  await sleep(1000)                                            // hope diagnostics arrived
}
```

Every file-changing helper funneled through this, and it has two races, neither caused by `xvfb-run`:

1. **Premature idle.** `processFileChange` runs *after* the filesystem mutation and has no pre-mutation baseline, so it can't distinguish "idle because the change is fully processed" from "idle because the file-system watcher hasn't fired yet". On a loaded CI runner the `sleep(1000)` is too short, the job queue is still empty, `allJobsFinished` returns immediately, and the test proceeds against stale state.
2. **Diagnostics delivery.** The trailing `sleep(1000)` is a guess that `publishDiagnostics` has been applied to VS Code's diagnostics collection.

## Fix

Synchronize on an actual signal instead of guessing with sleeps — for the in-test mutations, where assertions immediately follow a change and the flakiness actually bites.

- **`flix.checkCount` test command** (`notifications.ts` + `extension.ts`): a counter incremented once per `lsp/check` response, ticked on the `internalDiagnostics` notification — which the server sends *before* `internalFinishedAllJobs`.
- **`awaitCheck(mutation)`** (`util.ts`): baselines the check count **before** the mutation, runs it, waits for the count to advance, then waits for idle. The in-test mutators (`addFile`, `deleteFile`, `copyFile`, `replaceDocumentContent`, `typeText`) go through it.

### Why this is race-free

- Baselining *before* the mutation means we never sample idle until the `lsp/check` triggered by our change has completed — fixes (1).
- Because the server sends all `publishDiagnostics` before `internalFinishedAllJobs` on the same ordered channel, the diagnostics collection is already current once idle resolves — fixes (2), no trailing sleep needed.
- `waitForCheckSince` has a soft 20s cap that warns and falls back to the idle wait, so a no-op change or a cold-CI compiler download can't hang the suite. (This is also strictly more forgiving than the old fixed 2s of sleeps.)

### Why `init` keeps the sleep-based wait

`awaitCheck` is only valid when the extension is **already active and idle** so it can baseline the check count. That does not hold during `init`'s `copyWorkspace`, which runs *before* the extension activates: the first command (`getCheckCount`) would trigger activation, flipping the original ordering where `clearDir` runs before activation (so the compiler's initial discovery sees the *cleared* workspace), and the initial compile then interleaves with the clear/copy watcher events. So the two init-only helpers — the `clearDir` step and `copyDirContents` — retain the original `processFileChange` (sleep → idle → sleep), preserving the proven setup behavior.

| Helper | Used in | Wait strategy |
|--------|---------|---------------|
| `clearDir` step, `copyDirContents` | `init` only (pre-activation) | `processFileChange` (sleep + idle + sleep) |
| `addFile`, `deleteFile`, `copyFile`, `replaceDocumentContent`, `typeText` | test bodies (active + idle) | `awaitCheck` (baseline → mutate → wait for check → idle) |

No server or protocol changes.

## Testing

Type-check (client + test), `prettier --check`, and `eslint .` all pass locally. The test suite itself is exercised on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)