### PR TITLE
feat: add LSP folding ranges for comments

### DIFF
--- a/client/src/protocol/requests.ts
+++ b/client/src/protocol/requests.ts
@@ -48,6 +48,7 @@ export enum Request {
   lspWorkspaceSymbols = 'lsp/workspaceSymbols',
   lspShowAst = 'lsp/showAst',
   lspFormatting = 'lsp/formatting',
+  lspFoldingRange = 'lsp/foldingRange',
 
   internalReady = 'ext/ready', // Internal Extension Request
   internalMessage = 'ext/message', // Internal Extension Request

--- a/server/src/engine/jobs.ts
+++ b/server/src/engine/jobs.ts
@@ -51,6 +51,7 @@ export enum Request {
   lspSemanticTokens = 'lsp/semanticTokens',
   lspShowAst = 'lsp/showAst',
   lspFormatting = 'lsp/formatting',
+  lspFoldingRange = 'lsp/foldingRange',
 
   internalReady = 'ext/ready', // Internal Extension Request
   internalMessage = 'ext/message', // Internal Extension Request

--- a/server/src/handlers/lifecycle.ts
+++ b/server/src/handlers/lifecycle.ts
@@ -95,6 +95,7 @@ export function handleInitialize(_params: InitializeParams) {
         full: true,
       },
       documentFormattingProvider: true,
+      foldingRangeProvider: true,
     },
   }
 

--- a/server/src/handlers/symbols.ts
+++ b/server/src/handlers/symbols.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { FoldingRange, FoldingRangeParams } from 'vscode-languageserver'
+
 import * as jobs from '../engine/jobs'
 import * as engine from '../engine'
 import * as socket from '../engine/socket'
@@ -24,6 +26,21 @@ import { makePositionalHandler, makeEnqueuePromise, makeDefaultResponseHandler }
  * @function
  */
 export const handleDocumentSymbols = makePositionalHandler(jobs.Request.lspDocumentSymbols)
+
+/**
+ * Handle folding range requests.
+ *
+ * @param params - The folding range parameters.
+ * @returns A promise that resolves to an array of folding ranges.
+ */
+export const handleFoldingRanges = (params: FoldingRangeParams): Promise<FoldingRange[]> =>
+  new Promise(function (resolve) {
+    const uri = params.textDocument?.uri
+    const job = engine.enqueueJobWithFlattenedParams(jobs.Request.lspFoldingRange, { uri })
+    socket.eventEmitter.once(job.id, ({ result }: socket.FlixResponse) => {
+      resolve((result ?? []) as unknown as FoldingRange[])
+    })
+  })
 
 /**
  * @function

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -83,6 +83,9 @@ connection.onDocumentSymbol(handlers.handleDocumentSymbols)
 // Find WorkspaceSymbols information.
 connection.onWorkspaceSymbol(handlers.handleWorkspaceSymbols)
 
+// Folding ranges (e.g. collapsible multi-line comments)
+connection.onFoldingRanges(handlers.handleFoldingRanges)
+
 connection.onCodeAction(handlers.handleCodeAction)
 
 // Semantic tokens

--- a/test/src/foldingRanges.test.ts
+++ b/test/src/foldingRanges.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { getTestDocUri, init, open } from './util'
+
+suite('FoldingRangeProvider', () => {
+  const mainDocUri = getTestDocUri('src/Main.flix')
+
+  suiteSetup(async () => {
+    await init('foldingRanges')
+  })
+
+  test('Should fold multi-line doc, line, and block comments', async () => {
+    await open(mainDocUri)
+    const ranges = await vscode.commands.executeCommand<vscode.FoldingRange[]>(
+      'vscode.executeFoldingRangeProvider',
+      mainDocUri,
+    )
+
+    // Lines are zero-indexed. See `test/testWorkspaces/foldingRanges/src/Main.flix`.
+    const actual = ranges.map(r => ({ start: r.start, end: r.end, kind: r.kind })).sort((a, b) => a.start - b.start)
+
+    const expected = [
+      { start: 0, end: 2, kind: vscode.FoldingRangeKind.Comment }, // the `///` doc comment
+      { start: 4, end: 6, kind: vscode.FoldingRangeKind.Comment }, // the `//` line comment
+      { start: 9, end: 12, kind: vscode.FoldingRangeKind.Comment }, // the `/* ... */` block comment
+    ]
+
+    assert.deepStrictEqual(actual, expected)
+  })
+})

--- a/test/testWorkspaces/foldingRanges/flix.toml
+++ b/test/testWorkspaces/foldingRanges/flix.toml
@@ -1,0 +1,6 @@
+[package]
+name        = "vscode-flix-test"
+description = "test"
+version     = "0.1.0"
+flix        = "0.44.0"
+authors     = ["John Doe <john@example.com>"]

--- a/test/testWorkspaces/foldingRanges/src/Main.flix
+++ b/test/testWorkspaces/foldingRanges/src/Main.flix
@@ -1,0 +1,14 @@
+/// A doc comment
+/// that spans
+/// three lines.
+def main(): Unit \ IO =
+    // A line comment
+    // that spans
+    // multiple lines.
+    println(f())
+
+/*
+ * A block comment
+ * that spans multiple lines.
+ */
+def f(): Int32 = 42


### PR DESCRIPTION
Adds support for the `textDocument/foldingRange` LSP request so multi-line comments can be collapsed (folded) in the editor — the extension side of flix/flix#12905.

## Wiring

Follows the same request/response pattern as the existing features (e.g. formatting / document symbols):

- **`server/src/handlers/lifecycle.ts`** — declares the `foldingRangeProvider` capability.
- **`server/src/engine/jobs.ts`** — adds the `lsp/foldingRange` request (matches the string parsed by `VSCodeLspServer` on the compiler side).
- **`server/src/handlers/symbols.ts`** — adds `handleFoldingRanges`. It is a URI-only request (no position/range), so it enqueues `{ uri }` and resolves with the result array.
- **`server/src/server.ts`** — registers `connection.onFoldingRanges`.
- **`client/src/protocol/requests.ts`** — mirrors the request enum. The provider itself is auto-registered on the client by `vscode-languageclient` from the server capability, so no other client code is needed.

The wire format lines up exactly: the compiler returns `{ startLine, endLine, kind }` with zero-indexed lines and kind `comment`, which `vscode-languageclient` maps straight to `vscode.FoldingRange` / `FoldingRangeKind.Comment`.

## Test

Adds `test/src/foldingRanges.test.ts` and a `foldingRanges` test workspace whose `Main.flix` exercises all three foldable comment kinds (a `///` doc-comment run, a `//` line-comment run, and a `/* … */` block comment). The test asserts `vscode.executeFoldingRangeProvider` returns exactly those three ranges.