### PR TITLE
test: wait for the setup compile deterministically in workspace init

### DIFF
--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -26,7 +26,16 @@ import * as vscode from 'vscode'
 const CHECK_TIMEOUT_MS = 20000
 
 /**
- * Activates the extension and copies the contents of the given test workspace directory into the active workspace.
+ * How long to wait for the compiler to stay quiescent before considering a batch of workspace file
+ * changes fully settled. Must exceed the reconciliation debounce in the client's file watchers
+ * (`scheduleReconciliation`, currently 300ms), which can enqueue a follow-up check *after* the
+ * change's initial check has already gone idle. See {@linkcode settleAfterChange}.
+ */
+const RECONCILE_SETTLE_MS = 500
+
+/**
+ * Activates the extension and swaps the active workspace to the contents of the given test workspace
+ * directory, waiting deterministically for the compiler to finish compiling the result.
  *
  * @param testWorkspaceName The name of the workspace directory to copy, e.g. `codeActions`.
  */
@@ -43,52 +52,72 @@ export async function init(testWorkspaceName: string) {
     throw new Error('Failed to activate extension')
   }
 
-  await copyWorkspace(testWorkspaceName)
+  vscode.commands.executeCommand('workbench.action.closeAllEditors')
+  const activeWorkspaceUri = vscode.workspace.workspaceFolders![0].uri
 
-  // This includes the time it takes for the compiler to download
-  // The time it takes for the compiler to start will be awaited in the first command sent to the extension
+  // The `flix.checkCount` synchronization used below only works once the extension is running.
+  //
+  // On the very first suite the extension has not started yet: there is no check baseline to capture
+  // and no file-system watcher to report the changes below, so the copied files are instead picked
+  // up by the initial workspace scan performed when `ext.activate()` runs. On every later suite the
+  // extension is already active and we synchronize on the checks its watchers trigger.
+  const wasActive = ext.isActive
+
+  // Remove the previous suite's files. When the extension is already running, wait for the compiler
+  // to observe the removals *before* copying the new files. Otherwise VS Code can coalesce a
+  // delete-then-create of the same path into a single change event, which the file-system watcher
+  // does not handle — leaving the compiler with stale file contents.
+  const clearBaseline = wasActive ? await getCheckCount() : 0
+  const removedFlixFiles = await clearDir(activeWorkspaceUri)
+  if (wasActive && removedFlixFiles > 0) {
+    await settleAfterChange(clearBaseline)
+  }
+
+  // Copy in the new workspace.
+  const copyBaseline = wasActive ? await getCheckCount() : 0
+  const testWorkspacePath = path.resolve(__dirname, '../testWorkspaces', testWorkspaceName)
+  await copyDirContents(vscode.Uri.file(testWorkspacePath), activeWorkspaceUri)
+
+  // Ensure the extension is active. On the first suite this starts (and, on a cold CI run,
+  // downloads) the compiler and triggers the initial scan+compile of the files copied above.
   await ext.activate()
+
+  // Wait for the compiler to finish compiling the new workspace and go idle.
+  await settleAfterChange(copyBaseline)
 }
 
 /**
- * Clears the test workspace, and copies the contents of the given test workspace directory into the active workspace.
+ * Recursively deletes all test-owned files (matched by extension) from `uri`, always keeping
+ * `.gitkeep` and `flix.jar`.
  *
- * @param testWorkspaceName The name of the workspace directory to copy, e.g. `codeActions`.
+ * @returns the number of `.flix` files that were removed, so the caller can tell whether the
+ * deletion will trigger a recompile to wait for.
  */
-async function copyWorkspace(testWorkspaceName: string) {
-  vscode.commands.executeCommand('workbench.action.closeAllEditors')
+async function clearDir(uri: vscode.Uri): Promise<number> {
+  const contents = await vscode.workspace.fs.readDirectory(uri)
 
-  const activeWorkspaceUri = vscode.workspace.workspaceFolders![0].uri
+  // Recurse into subdirectories
+  const dirs = contents.filter(([_, type]) => type === vscode.FileType.Directory)
+  const dirUris = dirs.map(([name, _]) => vscode.Uri.joinPath(uri, name))
+  const removedInSubdirs = await Promise.all(dirUris.map(clearDir))
 
-  /** Recursively clears all safe files from the given directory. */
-  async function clearDir(uri: vscode.Uri) {
-    const contents = await vscode.workspace.fs.readDirectory(uri)
+  const files = contents.filter(([_, type]) => type !== vscode.FileType.Directory)
+  const fileNames = files.map(([name, _]) => name)
 
-    // Recurse into subdirectories
-    const dirs = contents.filter(([_, type]) => type === vscode.FileType.Directory)
-    const dirUris = dirs.map(([name, _]) => vscode.Uri.joinPath(uri, name))
-    await Promise.allSettled(dirUris.map(clearDir))
+  // Be careful, and only delete files with known extensions
+  const extensionsToDelete = ['flix', 'toml', 'jar', 'fpkg', 'txt']
 
-    const files = contents.filter(([_, type]) => type !== vscode.FileType.Directory)
-    const fileNames = files.map(([name, _]) => name)
+  // Always keep .gitkeep and flix.jar
+  const namesToKeep = ['.gitkeep', 'flix.jar']
 
-    // Be careful, and only delete files with known extensions
-    const extensionsToDelete = ['flix', 'toml', 'jar', 'fpkg', 'txt']
+  const namesToDelete = fileNames.filter(
+    name => !namesToKeep.includes(name) && extensionsToDelete.includes(name.split('.').at(-1)),
+  )
+  const urisToDelete = namesToDelete.map(name => vscode.Uri.joinPath(uri, name))
+  await Promise.allSettled(urisToDelete.map(uri => vscode.workspace.fs.delete(uri)))
 
-    // Always keep .gitkeep and flix.jar
-    const namesToKeep = ['.gitkeep', 'flix.jar']
-
-    const namesToDelete = fileNames.filter(
-      name => !namesToKeep.includes(name) && extensionsToDelete.includes(name.split('.').at(-1)),
-    )
-    const urisToDelete = namesToDelete.map(name => vscode.Uri.joinPath(uri, name))
-    await Promise.allSettled(urisToDelete.map(uri => vscode.workspace.fs.delete(uri)))
-  }
-  await clearDir(activeWorkspaceUri)
-  await processFileChange()
-
-  const testWorkspacePath = path.resolve(__dirname, '../testWorkspaces', testWorkspaceName)
-  await copyDirContents(vscode.Uri.file(testWorkspacePath), activeWorkspaceUri)
+  const removedHere = namesToDelete.filter(name => name.endsWith('.flix')).length
+  return removedHere + removedInSubdirs.reduce((sum, n) => sum + n, 0)
 }
 
 /**
@@ -174,23 +203,30 @@ async function awaitIdle() {
 }
 
 /**
- * Waits for the processing of a filesystem change to finish, using fixed sleeps to bracket the idle
- * wait.
+ * Waits for the compiler to finish reacting to a batch of workspace file changes (the setup in
+ * {@linkcode init}) and reach a stable idle state, given the {@linkcode getCheckCount} value
+ * observed *before* the changes were made.
  *
- * Only used for the workspace setup in {@linkcode init}, which runs *before* the extension is
- * active: there is no idle baseline to capture and the very first command triggers activation, so
- * the check-count strategy used by {@linkcode awaitCheck} does not apply. In-test mutations (which
- * run while the extension is active and idle) use {@linkcode awaitCheck} instead.
+ * Unlike a fixed sleep, this is anchored to observable compiler progress:
+ *
+ * 1. {@linkcode waitForCheckSince} blocks until the file-system watcher has fired and a check has
+ *    completed, so we never sample idle against stale, pre-change state.
+ * 2. We then repeatedly drain the queue ({@linkcode awaitIdle}) until the observed check count stops
+ *    advancing across a full {@linkcode RECONCILE_SETTLE_MS} window. A create/delete schedules a
+ *    debounced reconciliation that can enqueue a *follow-up* check (e.g. when VS Code delivers a
+ *    single folder-level event instead of per-file events), so returning on the first idle would be
+ *    premature.
  */
-async function processFileChange() {
-  // Wait for the file system watcher to pick up the change
-  await sleep(1000)
-
-  // Wait for the compiler to process the change
-  await awaitIdle()
-
-  // Wait for the diagnostics to be updated
-  await sleep(1000)
+async function settleAfterChange(baseline: number) {
+  await waitForCheckSince(baseline)
+  for (;;) {
+    await awaitIdle()
+    const count = await getCheckCount()
+    await sleep(RECONCILE_SETTLE_MS)
+    if ((await getCheckCount()) === count) {
+      return
+    }
+  }
 }
 
 /**
@@ -227,7 +263,11 @@ export async function addFile(uri: vscode.Uri, content: string | Uint8Array) {
 }
 
 /**
- * Copies the contents of the given folder `from` to the folder `to`, leaving non-overlapping files intact.
+ * Copies the contents of the given folder `from` to the folder `to`, leaving non-overlapping files
+ * intact.
+ *
+ * Does not wait for the compiler to react — callers synchronize via {@linkcode settleAfterChange}
+ * (workspace setup) or {@linkcode awaitCheck} (in-test mutations).
  */
 export async function copyDirContents(from: vscode.Uri, to: vscode.Uri) {
   const contents = await vscode.workspace.fs.readDirectory(from)
@@ -236,7 +276,6 @@ export async function copyDirContents(from: vscode.Uri, to: vscode.Uri) {
   const uris = names.map(name => ({ from: vscode.Uri.joinPath(from, name), to: vscode.Uri.joinPath(to, name) }))
 
   await Promise.allSettled(uris.map(({ from, to }) => vscode.workspace.fs.copy(from, to, { overwrite: true })))
-  await processFileChange()
 }
 
 /**


### PR DESCRIPTION
## Problem

CI still shows intermittent VS Code extension test failures ([example run](https://github.com/flix/flix/actions/runs/28450058403/job/84309591012?pr=12934)):

```
1) RenameProvider Should rename variable:      Error: No result.
2) RenameProvider Should rename variable-use:   Error: No result.
```

`Error: No result.` means the `vscode.executeDocumentRenameProvider` request came back empty — the server's index had no symbol at that position because the workspace hadn't been compiled yet when the test ran.

## Root cause

#545 converted **in-test file mutations** to wait on `lsp/check` via `awaitCheck`, but the **per-suite workspace swap** in `init` still used fixed sleeps (`processFileChange`: `sleep(1000)` → `awaitIdle` → `sleep(1000)`).

`awaitIdle` (`flix.allJobsFinished`) resolves *immediately* whenever the compiler's queue is momentarily empty — which it is if the file-system watcher hasn't fired yet after `copyDirContents`. Under CI load, `init` could return before the check triggered by copying the suite's files had finished compiling them.

`RenameProvider` (suite #12) does no in-test mutation, so it never benefits from `awaitCheck` — its correctness depends entirely on `init` leaving the workspace compiled and idle. Hence the residual flakiness.

## Fix

Make the setup path deterministic, the same way the mutation path already is:

- **`settleAfterChange(baseline)`** waits for `checkCount` to advance past a baseline captured *before* the change (proving the watcher fired and a check completed), then repeatedly drains to idle until the check count is stable across a reconcile-debounce window (the client schedules a 300 ms-debounced reconciliation that can enqueue a follow-up check).
- **`init`** baselines and settles separately for the *clear* and the *copy*, and waits for the removals to be observed before copying — so VS Code reports the new files as creates rather than coalescing a delete-then-create of the same path into a single (unhandled) change event.
- The **first suite** (extension not yet active) has no watcher/baseline; its copied files are picked up by the initial workspace scan on `ext.activate()`, and `settleAfterChange(0)` waits for that compile.
- Removes the now-unused `processFileChange`.

Net effect: the fixed ~4 s of per-suite sleeps are replaced by a deterministic wait anchored to observable compiler progress (typically faster, and no longer racy).

## Testing

`npm run build` and `tsc --build ./test` pass. The change is timing-only in the test harness; validated end-to-end on CI (local single runs can't reproduce load-dependent flakiness).