### PR TITLE
feat: Open VSX publishing

### DIFF
--- a/.github/workflows/publish-open-vsx
+++ b/.github/workflows/publish-open-vsx
@@ -1,0 +1,27 @@
+name: Publish to Open VSX
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  NODE_VERSION: '24.x'
+
+jobs:
+  publish-open-vsx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Package extension
+        run: npx --yes @vscode/vsce package
+      - name: Publish to Open VSX Registry
+        run: npx --yes ovsx publish flix-*.vsix -p "$OVSX_PAT"
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/activeWorkspace
 flix.jar
 *.vsix
 tsconfig.tsbuildinfo
+.DS_Store


### PR DESCRIPTION
Fixes https://github.com/flix/vscode-flix/issues/497

Add a GHA workflow to automatically deploy new versions of the Flix VS Code extension to the Open VSX marketplace, such that they may be installed identically in Cursor to the process for VS Code.

Also added .DS_Store to .gitignore as a chore.

Note that this will require adding OVSX_PAT as a repository secret.